### PR TITLE
French rev: almost total revision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+Basic_Common/CalendarCycleComputationEngine.js

--- a/Basic_Common/CBCCE.js
+++ b/Basic_Common/CBCCE.js
@@ -1,0 +1,144 @@
+/* The Cycle-based Calendar Computation Engine/ CBCCE
+//
+// Character set is UTF-8
+//
+// The functions of this package performs intercalation computations for calendars
+// that set intercalation elements following regular cycles.
+// This applies to the Milesian calendar, that adds or substracts intercalary days only at end of cycles, including months.
+// This applies also to calendars that shift the long year by one at cyclic periods 
+// e.g. the long year comes after 5 years instead of 4 years in certain circumstances.
+// A possible algorithmic implementation of the French Revolutionary "Franciade" uses such cycles.
+// For other calendars, including Gregorian and Julian, this routines may be used to compute
+// the rank of a day within a year, and then hours, minutes, seconds and milliseconds.
+// Computations on months require more specific algorithms.
+// The principles of these routines are explained in "L'heure milésienne" (for the first version)
+// a book by Louis-Aimé de Fouquières.
+//
+// Version 1 : M2017-06-26
+// This version is an extension of the original "Calendar Cycle Computation Engine" and replaces it.
+//
+*//////////////////////////////////////////////////////////////////////////////////////////////
+/* Copyright Miletus 2016-2017 - Louis A. de Fouquières
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 1. The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+// 2. Changes with respect to any former version shall be documented.
+//
+// The software is provided "as is", without warranty of any kind,
+// express of implied, including but not limited to the warranties of
+// merchantability, fitness for a particular purpose and noninfringement.
+// In no event shall the authors of copyright holders be liable for any
+// claim, damages or other liability, whether in an action of contract,
+// tort or otherwise, arising from, out of or in connection with the software
+// or the use or other dealings in the software.
+// Inquiries: www.calendriermilesien.org
+*////////////////////////////////////////////////////////////////////////////////
+var Chronos = { // Set of chronological constants generally used when handling Unix dates.
+  DAY_UNIT : 86400000, // One day in Unix time units
+  HOUR_UNIT : 3600000,
+  MINUTE_UNIT : 60000,
+  SECOND_UNIT : 1000
+}
+/* Parameter object structure. Replace # with numbers or literals.
+var decomposeParameterExample = {
+	timeepoch : #, origin time in milliseconds (or in the suitable unit) to be used for the decomposition, with respect to 1/1/1970 00:00 UTC.
+	coeff : [ // This array holds the coefficient used to decompose a time stamp into time cycles like eras, quadrisaeculae, centuries etc.
+		{cyclelength : #, //length of the cycle, expressed in milliseconds.
+		ceiling : #, // Infinity, or the maximum number of cycles of this size minus one in the upper cycle; the last cycle may hold an intercalary unit.
+		subCycleShift : #, number (-1, 0 or +1) to add to the ceiling of the cycle of the next level when the ceiling is reached at this level.
+		multiplier : #, // multiplies the number of cycle of this level to convert into target units.
+		target : #, // the unit (e.g. "year") of the decomposition element at this level. 
+		} ,
+		{ // similar elements at the lower cycle level 
+		} // end of array element
+	], // End of this array, but not end of object
+	canvas : [ // this last array is the canvas of the decomposition , e.g. "year", "month", "date", with suitable properties at each level.
+		{ name : #, // the name of the property at this level, which must match one target property of the coeff component,
+		init : #, // value of this component at epoch, and lowest value (except for the first component), e.g. 0 for month, 1 for date, 0 for hours, minutes, seconds.
+		} // End of array element (only two properties)
+	] // End of second array
+}	// End of object.
+// Constraints: 
+//	1. 	The cycles and the canvas elements shall be definined from the larger to the smaller 
+//		e.g. quadrisaeculum, then century, then quadriannum, then year, etc.
+//	2. 	The same names shall bu used for the "coeff" and the "canvas" properties, elsewise applications may return "NaN".
+//		
+*/
+var
+Day_milliseconds = { 	// To convert a time or a duration to and from days + milliseconds in day.
+	timeepoch : 0, 
+	coeff : [ // to be used with a Unix timestamp in ms. Decompose into days and milliseconds in day.
+	  {cyclelength : 86400000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "day_number"}, 
+	  {cyclelength : 1, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "milliseconds_in_day"}
+	],
+	canvas : [
+		{name : "day_number", init : 0},
+		{name : "milliseconds_in_day", init : 0},
+	]
+}
+/////////////////////////////////////////////
+// cbcceDecompose : from time serie figure to decomposition
+///////////////////////////////////////////// 
+function cbcceDecompose (quantity, params) { // from a chronological number, build an compound object holding the elements as required by cparams.
+  quantity -= params.timeepoch; // set at initial value the quantity to decompose into cycles.
+  var result = new Object(); // Construct intitial compound result 
+  for (let i = 0; i < params.canvas.length; i++) {	// Define property of result object (a date or date-time)
+    Object.defineProperty (result, params.canvas[i].name, {enumerable : true, writable : true, value : params.canvas[i].init});
+  }
+  let addCycle = 0; 	// flag that upper cycle has one element more or less (i.e. a 5 years franciade or 13 months luni-solar year)
+  for (let i = 0; i < params.coeff.length; ++i) {	// Perform decomposition by dividing by the successive cycle length
+    let r = 0; // r is the computed quotient for this level of decomposition
+    if (params.coeff[i].cyclelength == 1) r = quantity; // avoid performing a trivial divison by 1.
+    else {		// at each level, search at the same time the quotient (r) and the modulus (quantity)
+      while (quantity < 0) {
+        --r; 
+        quantity += params.coeff[i].cyclelength;
+      }
+	  let ceiling = params.coeff[i].ceiling + addCycle;
+      while ((quantity >= params.coeff[i].cyclelength) && (r < ceiling)) {
+        ++r; 
+        quantity -= params.coeff[i].cyclelength;
+      }
+	  addCycle = (r == ceiling) ? params.coeff[i].subCycleShift : 0; // if at last section of this cycle, add or substract 1 to the ceiling of next cycle
+    }
+    result[params.coeff[i].target] += r*params.coeff[i].multiplier; // add result to suitable part of result array	
+  }	
+  return result;
+}
+////////////////////////////////////////////
+// cbcceCompose: from compound object to time serie figure.
+////////////////////////////////////////////
+function cbcceCompose (cells, params) { // from an object cells structured as params.canvas, compute the chronological number
+	var quantity = params.timeepoch ; // initialise Unix quantity to computation epoch
+	for (let i = 0; i < params.canvas.length; i++) { // cells value shifted as to have all 0 if at epoch
+		cells[params.canvas[i].name] -= params.canvas[i].init
+	}
+	let currentTarget = params.coeff[0].target; 	// Set to uppermost unit used for date (year, most often)
+	let currentCounter = cells[params.coeff[0].target];	// This counter shall hold the successive remainders
+	let addCycle = 0; 	// This flag says whether there is an additionnal period at end of cycle, e.g. a 5th year in the Franciade or a 13th month
+	for (let i = 0; i < params.coeff.length; i++) {
+		let f = 0;				// Number of "target" values (number of years, to begin with)
+		if (currentTarget != params.coeff[i].target) {	// If we go to the next level (e.g. year to month), reset variables
+			currentTarget = params.coeff[i].target;
+			currentCounter = cells[currentTarget];
+		}
+		let ceiling = params.coeff[i].ceiling + addCycle;
+		while (currentCounter < 0) {
+			--f;
+			currentCounter += params.coeff[i].multiplier;
+		}
+		while ((currentCounter >= params.coeff[i].multiplier) && (f < ceiling)) {
+			++f;
+			currentCounter -= params.coeff[i].multiplier;
+		}
+		addCycle = (f == ceiling) ? params.coeff[i].subCycleShift : 0;
+		quantity += f * params.coeff[i].cyclelength;
+	}
+	return quantity ;	
+}

--- a/Basic_Common/CalendarCycleComputationEngine.js
+++ b/Basic_Common/CalendarCycleComputationEngine.js
@@ -15,6 +15,7 @@
 // Version 2: 
 //	Changed the names of the functions
 //	The parameters are now in each package. Only very common parameters and variables are defined here.
+// Version 2.1 : M2017-12-14 (typos in commments)
 //
 *//////////////////////////////////////////////////////////////////////////////////////////////
 /* Copyright Miletus 2016-2017 - Louis A. de Fouquières
@@ -51,7 +52,7 @@ var decomposeParameterExample = {
 		{cyclelength : #, //length of the cycle, expressed in milliseconds.
 		ceiling : #, // Infinity, or the maximum number of cycles of this size minus one in the upper cycle; the last cycle may hold an intercalary unit.
 		multiplier : #, // multiplies the number of cycle of this level to convert into target units.
-		targer : #, // the unit (e.g. "year") of the decomposition element at this level. 
+		target : #, // the unit (e.g. "year") of the decomposition element at this level. 
 		} ,
 		{ // similar elements at the lower cycle level 
 		} // end of array element
@@ -109,7 +110,7 @@ function ccceDecompose (quantity, params) { // from a chronological number, buil
 ////////////////////////////////////////////
 // ccceCompose: from compound object to time serie figure.
 ////////////////////////////////////////////
-function ccceCompose (cells, params) { // from an object structured as params.canvas, compute the chronological number
+function ccceCompose (cells, params) { // from an object 'cells' structured as params.canvas, compute the chronological number
 	var quantity = params.timeepoch ; // initialise quantity
 	for (let i = 0; i < params.canvas.length; i++) { // cells value shifted as to have all 0 if at epoch
 		cells[params.canvas[i].name] -= params.canvas[i].init

--- a/Basic_Common/MilesianAlertMsg.js
+++ b/Basic_Common/MilesianAlertMsg.js
@@ -1,7 +1,10 @@
 // MilesianAlertMsg
 // Language dependant messages to be used with Milesian demonstrator routines
 // This version UTF-8 to be recoded as necessary
-// M2017-08-15
+// M2017-12-23
+//  Changes from M2017-08:
+//		Delete MilesianAlertMsg object (not used anymore)
+//		Suppress ":" at end of messages, but leave " " (blank character)
 /* Copyright Miletus 2016-2017 - Louis A. de Fouquières
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,34 +26,29 @@
 // or the use or other dealings in the software.
 // Inquiries: www.calendriermilesien.org
 */
-var
-	MilesianAlertMsg = {						// for compatibility until all display routines corrected.
-		nonNumeric : "Entrée non numérique : ",
-		nonInteger : "Entrée non entière : "
-	}
 function milesianAlertMsg (inputError) {	// Prepare an error message in suitable language
 	var	languages = [ "en", "fr", "de", "es", "pt" ];
 	var errorMsg = {
 		"nonNumeric" : { 
-			en	: "Non numeric entry: ",
-			fr	: "Entrée non numérique: ",
-			de	: "Nich digitale Einführung: ",
-			es	: "Entrada no digital: ",
-			pt	: "Entrada não-digital:"
+			en	: "Non numeric entry ",
+			fr	: "Entrée non numérique ",
+			de	: "Nich digitale Einführung ",
+			es	: "Entrada no digital ",
+			pt	: "Entrada não-digital "
 			},
 		"nonInteger" : {
-			en	: "Non integer entry: ",
-			fr	: "Entrée non entière: ",
-			de	: "Nicht integer Nummer: ",
-			es	: "Entrada no entera: ",
-			pt	: "Entrada não-inteira:"
+			en	: "Non integer entry ",
+			fr	: "Entrée non entière ",
+			de	: "Nicht integer Nummer ",
+			es	: "Entrada no entera ",
+			pt	: "Entrada não-inteira "
 			},
 		"invalidDate" : {
-			en	: "Invalid date or time: ",
-			fr	: "Date ou heure invalide: ",
-			de	: "Ungültiges Datum: ",
-			es	: "Fecha no válida: ",
-			pt	: "Data inválida: "
+			en	: "Invalid date or time ",
+			fr	: "Date ou heure invalide ",
+			de	: "Ungültiges Datum ",
+			es	: "Fecha no válida ",
+			pt	: "Data inválida "
 			}
 		};
 	let askedOptions = new Intl.DateTimeFormat(); let usedOptions = askedOptions.resolvedOptions(); // Current language... may be simplier.

--- a/Basic_Common/MilesianDateProperties.js
+++ b/Basic_Common/MilesianDateProperties.js
@@ -1,8 +1,8 @@
 /* Milesian properties added to Date
 // Character set is UTF-8
 // This code, to be manually imported, set properties to object Date for the Milesian calendar.
-// Version M2017-07-03
-// Package CalendarCycleComputationEngine is used.
+// Version M2017-12-16 : replace CalendarCycleComputationEngine with CBCCE
+// Package CBCCE is used.
 // File MilesianMonthNames.xml is not used in this version, the file has been stringified as "pldr".
 //  getMilesianDate : the day date as a three elements object: .year, .month, .date; .month is 0 to 11. Conversion is in local time.
 //  getMilesianUTCDate : same as above, in UTC time.
@@ -40,18 +40,18 @@
 var Milesian_time_params = { // To be used with a Unix timestamp in ms. Decompose into Milesian years, months, date, hours, minutes, seconds, ms
 	timeepoch : -188395804800000, // Unix timestamp of 1 1m -4000 00h00 UTC in ms
 	coeff : [ 
-	  {cyclelength : 100982160000000, ceiling : Infinity, multiplier : 3200, target : "year"},
-	  {cyclelength : 12622780800000, ceiling : Infinity, multiplier : 400, target : "year"},
-	  {cyclelength : 3155673600000, ceiling :  3, multiplier : 100, target : "year"},
-	  {cyclelength : 126230400000, ceiling : Infinity, multiplier : 4, target : "year"},
-	  {cyclelength : 31536000000, ceiling : 3, multiplier : 1, target : "year"},
-	  {cyclelength : 5270400000, ceiling : Infinity, multiplier : 2, target : "month"},
-	  {cyclelength : 2592000000, ceiling : 1, multiplier : 1, target : "month"}, 
-	  {cyclelength : 86400000, ceiling : Infinity, multiplier : 1, target : "date"},
-	  {cyclelength : 3600000, ceiling : Infinity, multiplier : 1, target : "hours"},
-	  {cyclelength : 60000, ceiling : Infinity, multiplier : 1, target : "minutes"},
-	  {cyclelength : 1000, ceiling : Infinity, multiplier : 1, target : "seconds"},
-	  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "milliseconds"}
+	  {cyclelength : 100982160000000, ceiling : Infinity, subCycleShift : 0, multiplier : 3200, target : "year"},
+	  {cyclelength : 12622780800000, ceiling : Infinity, subCycleShift : 0, multiplier : 400, target : "year"},
+	  {cyclelength : 3155673600000, ceiling :  3, subCycleShift : 0, multiplier : 100, target : "year"},
+	  {cyclelength : 126230400000, ceiling : Infinity, subCycleShift : 0, multiplier : 4, target : "year"},
+	  {cyclelength : 31536000000, ceiling : 3, subCycleShift : 0, multiplier : 1, target : "year"},
+	  {cyclelength : 5270400000, ceiling : Infinity, subCycleShift : 0, multiplier : 2, target : "month"},
+	  {cyclelength : 2592000000, ceiling : 1, subCycleShift : 0, multiplier : 1, target : "month"}, 
+	  {cyclelength : 86400000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "date"},
+	  {cyclelength : 3600000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "hours"},
+	  {cyclelength : 60000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "minutes"},
+	  {cyclelength : 1000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "seconds"},
+	  {cyclelength : 1, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "milliseconds"}
 	],
 	canvas : [ 
 		{name : "year", init : -4000},
@@ -67,15 +67,15 @@ var Milesian_time_params = { // To be used with a Unix timestamp in ms. Decompos
 // 2. Methods added to Date object for Milesian dates
 //
 Date.prototype.getMilesianDate = function () {
-  return ccceDecompose (this.getTime() - (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), Milesian_time_params);
+  return cbcceDecompose (this.getTime() - (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), Milesian_time_params);
 }
 Date.prototype.getMilesianUTCDate = function () {
-  return ccceDecompose (this.getTime(), Milesian_time_params);
+  return cbcceDecompose (this.getTime(), Milesian_time_params);
 }
 Date.prototype.setTimeFromMilesian = function (year, month, date, 
                                                hours = this.getHours(), minutes = this.getMinutes(), seconds = this.getSeconds(),
                                                milliseconds = this.getMilliseconds()) {
-  this.setTime(ccceCompose({
+  this.setTime(cbcceCompose({
 	  'year' : year, 'month' : month, 'date' : date, 'hours' : 0, 'minutes' : 0, 'seconds' : 0, 'milliseconds' : 0
 	  }, Milesian_time_params));			// Date is first specified at midnight UTC.
   this.setHours (hours, minutes, seconds, milliseconds); // Then hour part is specified
@@ -84,17 +84,17 @@ Date.prototype.setTimeFromMilesian = function (year, month, date,
 Date.prototype.setUTCTimeFromMilesian = function (year, month = 0, date = 1,
                                                hours = this.getUTCHours(), minutes = this.getUTCMinutes(), seconds = this.getUTCSeconds(),
                                                milliseconds = this.getUTCMilliseconds()) {
-  this.setTime(ccceCompose({
+  this.setTime(cbcceCompose({
 	  'year' : year, 'month' : month, 'date' : date, 'hours' : hours, 'minutes' : minutes, 'seconds' : seconds,
 	  'milliseconds' : milliseconds
 	  }, Milesian_time_params));
    return this.valueOf();
 }
 Date.prototype.toIntlMilesianDateString = function () {
-	var dateElements = ccceDecompose (this.getTime()- (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), Milesian_time_params );
+	var dateElements = cbcceDecompose (this.getTime()- (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), Milesian_time_params );
 	return dateElements.date+" "+(++dateElements.month)+"m "+dateElements.year;
 }
 Date.prototype.toUTCIntlMilesianDateString = function () {
-	var dateElements = ccceDecompose (this.getTime(), Milesian_time_params );
+	var dateElements = cbcceDecompose (this.getTime(), Milesian_time_params );
 	return dateElements.date+" "+(++dateElements.month)+"m "+dateElements.year;
 }

--- a/Basic_Common/milesian.css
+++ b/Basic_Common/milesian.css
@@ -30,3 +30,14 @@ button.dateconvert {
 	font-size:18px;
 	text-anchor:middle;
 }
+.clock {
+	font-family	: Sans-Serif;
+	text-anchor	: middle;
+}
+.ampm {
+	font-family	: Sans-Serif;
+	font-size	: 24px;
+}
+.yeardisplay {
+	font-size	: 42px;
+}

--- a/Basic_Common/milesian.css
+++ b/Basic_Common/milesian.css
@@ -5,6 +5,15 @@ p.date {
 .dateconvert {
 	text-align: center;
 }
+.daynum {
+	width: 3em;
+}
+.yearnum {
+	width: 4em;
+}
+.juliandaynum {
+	width : 7em;
+}
 button.dateconvert {
   background: darkblue;
   color: antiquewhite;

--- a/Date-Converter/DateConverter.html
+++ b/Date-Converter/DateConverter.html
@@ -4,17 +4,16 @@
 	<link href="milesian.css" rel="stylesheet"/>
 	<title>Convertisseur de dates</title>
  
-	<script type="text/javascript" src="CalendarCycleComputationEngine.js"></script>
-	<script type="text/javascript" src="CalendarShiftCycleComputationEngine.js"></script>
-	<script type="text/javascript" src="MilesianClockOperations.js"></script>
+	<script type="text/javascript" src="milesianMonthNamesString.js"></script>
+	<script type="text/javascript" src="CBCCE.js"></script>
 	<script type="text/javascript" src="MilesianDateProperties.js"></script>
 	<script type="text/javascript" src="IsoWeekCalendarDateProperties.js"></script>
 	<script type="text/javascript" src="JulianDateProperties.js"></script>
 	<script type="text/javascript" src="FrenchRevDateProperties.js"></script>
-	<script type="text/javascript" src="DateConverter.js"></script>
+	<script type="text/javascript" src="MilesianClockOperations.js"></script>
 	<script type="text/javascript" src="MilesianAlertMsg.js"></script>
-	<script type="text/javascript" src="milesianMonthNamesString.js"></script>
 	<script type="text/javascript" src="toMilesianString.js"></script>
+	<script type="text/javascript" src="DateConverter.js"></script>
 
 </head>
 <body>

--- a/Date-Converter/DateConverter.html
+++ b/Date-Converter/DateConverter.html
@@ -33,7 +33,7 @@
       <tr>
 	    <form name="milesian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntMilesian();">
         <td>M. </td>
-        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"></td>
         <td><select name="monthname" class="dateconvert" size="1">
 			<option value="0">1m</option>
 			<option value="1">2m</option>
@@ -48,14 +48,14 @@
 			<option value="10">11m</option>
 			<option value="11">12m</option>
 		</select></td>
-        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6" value=""> </td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
         <td><button name="Compute" class="dateconvert" value="milesian">Ok</button></td>
 		</form>
       </tr>
       <tr>
 		<form name="gregorian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntGregorian();">
         <td>G. </td>
-        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"> </td>
         <td><select name="monthname" class="dateconvert" size="1">
         <option value="0">janvier</option>
         <option value="1">février</option>
@@ -70,14 +70,14 @@
         <option value="10">novembre</option>
         <option value="11">décembre</option>
         </select></td>
-        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
         <td><button name="Compute" value="gregorian" class="dateconvert">Ok</button></td>
  		</form>
      </tr>	  
       <tr>
 		<form name="julian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntJulian();">
         <td>J. </td>
-        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"></td>
         <td><select name="monthname" class="dateconvert" size="1">
         <option value="0">janvier</option>
         <option value="1">février</option>
@@ -92,14 +92,14 @@
         <option value="10">novembre</option>
         <option value="11">décembre</option>
         </select></td>
-        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
         <td><button name="Compute" value="julian" class="dateconvert">Ok</button> </td>
  		</form>
      </tr>
       <tr>
 		<form name="republican" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntFrenchRev();">
         <td>R. </td>
-        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><input name="day" type="number" min="1" max="30" class="dateconvert daynum"> </td>
         <td><select name="monthname" class="dateconvert" size="1">
         <option value="0">Vendémiaire</option>
         <option value="1">Brumaire</option>
@@ -113,9 +113,9 @@
         <option value="9">Messidor</option>
         <option value="10">Thermidor</option>
         <option value="11">Fructidor</option>
-        <option value="12">Complémentaire</option>
+        <option value="12">Complément.</option>
         </select></td>
-        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
         <td><button name="Compute" value="republican" class="dateconvert">Ok</button> </td>
  		</form>
      </tr>
@@ -132,7 +132,7 @@
         <th></th>
       </tr>
 	<tr>
-		<form name="isoweeks" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcISO();">
+		<form name="isoweeks" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntISO();">
 		<td>S. </td>
 		<td> 
         <select name="day" class="dateconvert" size="1">
@@ -144,8 +144,8 @@
         <option value="6">samedi</option>
         <option value="7">dimanche</option>
         </select></td>
-        <td><input name="week" type="text" class="dateconvert" size="2" maxlength="3"> </td>
-        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><input name="week" type="number" class="dateconvert daynum"  min="1" max="53"> </td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
         <td><button name="Compute" value="isoweeks" class="dateconvert">Ok</button> </td>
 	  </form>
 	</tr>
@@ -155,7 +155,7 @@
   <tbody>
     <form name="daycounter" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntJulianDay();">
 	<tr><th>Jour julien : </th><td></td>
-		<td><input name="julianday" value="1" class="dateconvert" maxlength="12" size="12"></td>
+		<td><input name="julianday" type="number" value="1" class="dateconvert juliandaynum" maxlength="9" size="9"></td>
 		<td><button name="setday" value="julianday" class="dateconvert">Ok</button></td>
 	</tr>
 	</form>

--- a/Date-Converter/DateConverter.html
+++ b/Date-Converter/DateConverter.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html><head>
+	<meta content="text/html; charset=UTF-8" http-equiv="content-type">
+	<link href="milesian.css" rel="stylesheet"/>
+	<title>Convertisseur de dates</title>
+ 
+	<script type="text/javascript" src="CalendarCycleComputationEngine.js"></script>
+	<script type="text/javascript" src="CalendarShiftCycleComputationEngine.js"></script>
+	<script type="text/javascript" src="MilesianClockOperations.js"></script>
+	<script type="text/javascript" src="MilesianDateProperties.js"></script>
+	<script type="text/javascript" src="IsoWeekCalendarDateProperties.js"></script>
+	<script type="text/javascript" src="JulianDateProperties.js"></script>
+	<script type="text/javascript" src="FrenchRevDateProperties.js"></script>
+	<script type="text/javascript" src="DateConverter.js"></script>
+	<script type="text/javascript" src="MilesianAlertMsg.js"></script>
+	<script type="text/javascript" src="milesianMonthNamesString.js"></script>
+	<script type="text/javascript" src="toMilesianString.js"></script>
+
+</head>
+<body>
+<h1 class="dateconvert">Convertisseur de dates</h1>
+<p class="dateconvert">Convertissez une date dans une langue et un calendrier référencés par Unicode. Restrictions d'usage: voir infra.</p>
+<div class="dateconvert autoscroll">
+  <table class="dateconvert" align="center">
+   <tbody>
+      <tr>
+        <th>Cal.</th>
+        <th>Jour</th>
+        <th>Mois</th>
+        <th>Année</th>
+        <th></th>
+      </tr>
+      <tr>
+	    <form name="milesian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntMilesian();">
+        <td>M. </td>
+        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><select name="monthname" class="dateconvert" size="1">
+			<option value="0">1m</option>
+			<option value="1">2m</option>
+			<option value="2">3m</option>
+			<option value="3">4m</option>
+			<option value="4">5m</option>
+			<option value="5">6m</option>
+			<option value="6">7m</option>
+			<option value="7">8m</option>
+			<option value="8">9m</option>
+			<option value="9">10m</option>
+			<option value="10">11m</option>
+			<option value="11">12m</option>
+		</select></td>
+        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6" value=""> </td>
+        <td><button name="Compute" class="dateconvert" value="milesian">Ok</button></td>
+		</form>
+      </tr>
+      <tr>
+		<form name="gregorian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntGregorian();">
+        <td>G. </td>
+        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><select name="monthname" class="dateconvert" size="1">
+        <option value="0">janvier</option>
+        <option value="1">février</option>
+        <option value="2">mars</option>
+        <option value="3">avril</option>
+        <option value="4">mai</option>
+        <option value="5">juin</option>
+        <option value="6">juillet</option>
+        <option value="7">août</option>
+        <option value="8">septembre</option>
+        <option value="9">octobre</option>
+        <option value="10">novembre</option>
+        <option value="11">décembre</option>
+        </select></td>
+        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><button name="Compute" value="gregorian" class="dateconvert">Ok</button></td>
+ 		</form>
+     </tr>	  
+      <tr>
+		<form name="julian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntJulian();">
+        <td>J. </td>
+        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><select name="monthname" class="dateconvert" size="1">
+        <option value="0">janvier</option>
+        <option value="1">février</option>
+        <option value="2">mars</option>
+        <option value="3">avril</option>
+        <option value="4">mai</option>
+        <option value="5">juin</option>
+        <option value="6">juillet</option>
+        <option value="7">août</option>
+        <option value="8">septembre</option>
+        <option value="9">octobre</option>
+        <option value="10">novembre</option>
+        <option value="11">décembre</option>
+        </select></td>
+        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><button name="Compute" value="julian" class="dateconvert">Ok</button> </td>
+ 		</form>
+     </tr>
+      <tr>
+		<form name="republican" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntFrenchRev();">
+        <td>R. </td>
+        <td><input name="day" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><select name="monthname" class="dateconvert" size="1">
+        <option value="0">Vendémiaire</option>
+        <option value="1">Brumaire</option>
+        <option value="2">Frimaire</option>
+        <option value="3">Nivôse</option>
+        <option value="4">Pluviôse</option>
+        <option value="5">Ventôse</option>
+        <option value="6">Germinal</option>
+        <option value="7">Floréal</option>
+        <option value="8">Prairial</option>
+        <option value="9">Messidor</option>
+        <option value="10">Thermidor</option>
+        <option value="11">Fructidor</option>
+        <option value="12">Complémentaire</option>
+        </select></td>
+        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><button name="Compute" value="republican" class="dateconvert">Ok</button> </td>
+ 		</form>
+     </tr>
+   </tbody>
+</table>
+
+  <table class="dateconvert" align="center">
+   <tbody>
+     <tr>
+        <th></th>
+        <th>Jour</th>
+        <th>Semaine</th>
+        <th>Année</th>
+        <th></th>
+      </tr>
+	<tr>
+		<form name="isoweeks" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcISO();">
+		<td>S. </td>
+		<td> 
+        <select name="day" class="dateconvert" size="1">
+		<option value="1">lundi</option>
+        <option value="2">mardi</option>
+        <option value="3">mercredi</option>
+        <option value="4">jeudi</option>
+        <option value="5">vendredi</option>
+        <option value="6">samedi</option>
+        <option value="7">dimanche</option>
+        </select></td>
+        <td><input name="week" type="text" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><input name="year" type="text" class="dateconvert" size="5" maxlength="6"> </td>
+        <td><button name="Compute" value="isoweeks" class="dateconvert">Ok</button> </td>
+	  </form>
+	</tr>
+   </tbody>
+ </table>
+<table class="dateconvert" align="center">
+  <tbody>
+    <form name="daycounter" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcIntJulianDay();">
+	<tr><th>Jour julien : </th><td></td>
+		<td><input name="julianday" value="1" class="dateconvert" maxlength="12" size="12"></td>
+		<td><button name="setday" value="julianday" class="dateconvert">Ok</button></td>
+	</tr>
+	</form>
+  </tbody>
+</table>
+</div>
+<div>
+<table class="dateconvert" align="center">
+  <tbody>
+    <tr><form name="Today" class="dateconvert" method="post" action="Javascript:setDateToToday();">
+      <td><button name="Compute" value="Now" class="dateconvert" >Ce jour</button></td>
+  	  </form>
+	  <td> jours+/-</td>
+	<form name="control" class="dateconvert" autocomplete="off" method="post" action="Javascript:SetDayOffset();">
+	<td><button name="to" value="-1" class="dateconvert" formaction="Javascript:SetDayOffset(-1);" >-</button></td>
+	  <td><input name="shift" value="1" class="dateconvert"  maxlength="8" size="7"></td> 
+      <td><button name="to" value="+1" class="dateconvert" formaction="Javascript:SetDayOffset(1);">+</button></td>
+    </form></tr>
+   </tbody>
+</table>
+</div>
+<br>
+<div class="dateconvert">
+	<table class="dateconvert" align="center"> <tbody>
+	<form name="LocaleOptions" class="dateconvert" method="post" action="JavaScript:putStringOnOptions();">
+		<tr>
+			<th> Langue </th><th > Format </th>
+		</tr>
+		<tr>
+			<td><input name="Locale" type="text" autocomplete="language" class="dateconvert" size="5"> </td>
+			<td>
+			<select name="Presentation" class="dateconvert" size="1">
+				<option value="long">long</option>
+				<option value="textCumWeek" selected>texte avec semaine</option>
+				<option value="textSineWeek">texte sans semaine</option>
+				<option value="short">abrégé</option>
+				<option value="numeric">numérique</option>
+			</select>
+			</td>
+		</tr>
+		<tr>
+			<th colspan="2"> Calendrier </th>
+		</tr>
+		<tr>
+			<td colspan="2">
+			<select name="Calendar" size="1" class="dateconvert">
+				<option value="">par défaut</option>
+				<option value="buddhist">bouddhiste Thaï</option>
+				<option value="chinese">chinois traditionnel</option>
+				<option value="coptic">copte</option>
+				<option value="dangi">coréen traditionnel</option>
+				<option value="ethioaa">éthiopien Amete Alem (5493 A.C.) </option>
+				<option value="ethiopic">éthiopien Amete Mihret (8 A.D.)</option>
+				<option value="gregory">grégorien (proleptique)</option>
+				<option value="hebrew">hébraïque</option>
+				<option value="indian">indien moderne</option>
+				<option value="islamic">islamique standard</option>
+				<option value="islamic-umalqura">islamique Umm al-Qura</option>
+				<option value="islamic-tbla">islamique tabulaire astronomique</option>
+				<option value="islamic-civil">islamique tabulaire civil</option>
+				<option value="islamic-rgsa">islamique, Arabie saoudite</option>
+				<option value="iso8601">grégorien avec règles ISO 8601</option>
+				<option value="japanese">japonais impérial</option>
+				<option value="persian">persan</option>
+				<option value="roc">chinois de république populaire</option>
+			</select> 
+			</td>
+			<td><button name="Compute" value="options" class="dateconvert">Ok</button></td>	
+	   </tr>
+   	</form></tbody></table>
+</div>
+<h2 class="dateconvert">Date Unicode</h2>
+<h3 id="UnicodeString" class="dateconvert"></h3>
+<div class="dateconvert">
+<h2 class="dateconvert">Date milésienne</h2>
+<h3 id="milesianDisplay" class="dateconvert"></h3>
+<!-- put svg code inline -->
+<!-- Scalable viewbox, centered in the middle -->
+<svg width="300" height="100%" xml:lang="fr" 
+viewBox="-300 -300 600 600" preserveAspectRatio="xMidYMid meet"
+xmlns="http://www.w3.org/2000/svg" 
+xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="clock3">
+<!-- the dial -->
+<image xlink:href="Cadran_milesien_600.png" x="-300" y ="-300" width="600" height="599"/>
+<!-- the motto on the dial -->
+<text class="motto" x="0" y="36" >CERTUM MONSTRAT DIEM</text>
+<!-- main dial: month, day; the rect enables to fetch the center of the dial -->
+<rect class="center month day" x="0" y="0" width="0" height="0"/>
+<!-- the month hand -->
+  <g class="clockhand month" transform="rotate(0)"
+  opacity="0.8">										
+	<polygon points="0,0 20,-60 0,-165 -20,-60" />
+  </g>
+<!-- the day hand -->
+  <g class="clockhand day" transform="rotate(0)"
+  opacity="0.8" >									
+	<line x1="0" x2="0" y1="0" y2="-200" stroke-width="8px"/>
+  </g>
+<!-- center circle -->
+<circle class="clockhand" r="9" />
+</g>
+</svg>
+</div>	
+ <h3 class="dateconvert">© 2017-12m <a href="http://www.calendriermilesien.org">www.calendriermilesien.org</a></h3>
+<!-- If XMLHTTPRequest asynchronous used, the next instruction to be put in onload event handler -->
+ <script type="text/javascript" >setDateToToday();</script>
+</script>
+</body></html>

--- a/Date-Converter/DateConverter.js
+++ b/Date-Converter/DateConverter.js
@@ -1,11 +1,9 @@
 /* DateConverter - Display routines of the Milesian date converter.
 // Character set of this file is UTF-8 
 // Error messages in another file fo coding compatbility
-// Version M2017-12-21
+// Version M2017-12-26 : no reference to dependent files, adapt to Clock operation
 // 
 // to be used with the following .js files:
-//   CalendarCycleComputationEngine.js (used by other .js files)
-//   CalendarShiftCycleComputationEngine.js (used by other .js files)
 //	 MilesianAlertMsg.js (Error messages)
 //   MilesianDateProperties.js
 //	 IsoWeekCalendarDateProperties.js
@@ -133,7 +131,7 @@ function setDateDisplay () { // Considering that convertDate time has been set t
 	
 	// Set Milesian clock
 	let clock = document.querySelector("#clock3");
-	setSolarYearClockHands (clock, convertDate.getMilesianUTCDate().month, convertDate.getMilesianUTCDate().date);
+	setSolarYearClockHands (clock, convertDate.getMilesianDate().year, convertDate.getMilesianUTCDate().month, convertDate.getMilesianUTCDate().date);
 
 }
 

--- a/Date-Converter/DateConverter.js
+++ b/Date-Converter/DateConverter.js
@@ -1,0 +1,221 @@
+/* DateConverter - Display routines of the Milesian date converter.
+// Character set of this file is UTF-8 
+// Error messages in another file fo coding compatbility
+// Version M2017-12-21
+// 
+// to be used with the following .js files:
+//   CalendarCycleComputationEngine.js (used by other .js files)
+//   CalendarShiftCycleComputationEngine.js (used by other .js files)
+//	 MilesianAlertMsg.js (Error messages)
+//   MilesianDateProperties.js
+//	 IsoWeekCalendarDateProperties.js
+//	 JulianDateProperties.js
+//	 FrenchRevDateProperties.js
+// and with the suitable HTML page.
+// This version is for French end users.
+*/
+/* Copyright Miletus 2017 - Louis A. de Fouquières
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 1. The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+// 2. Changes with respect to any former version shall be documented.
+//
+// The software is provided "as is", without warranty of any kind,
+// express of implied, including but not limited to the warranties of
+// merchantability, fitness for a particular purpose and noninfringement.
+// In no event shall the authors of copyright holders be liable for any
+// claim, damages or other liability, whether in an action of contract,
+// tort or otherwise, arising from, out of or in connection with the software
+// or the use or other dealings in the software.
+// Inquiries: www.calendriermilesien.org
+*////////////////////////////////////////////////////////////////////////////////
+var convertDate = new Date() ; // This date will be used to update all displayed fields
+
+function putStringOnOptions() { // get Locale, calendar indication and Options given on page, print String; No control.
+	let Locale = document.LocaleOptions.Locale.value;
+	let Calendar = document.LocaleOptions.Calendar.value;
+	let Options; 		// to be computed later;
+	let valid = true; 	// by default, computations under Unicode are expected valid. Certains cases are known false.
+	if (Locale == ""){ 
+		if (Calendar !== "") {
+			let askedOptions = new Intl.DateTimeFormat ();
+			let usedOptions = askedOptions.resolvedOptions();
+			Locale = usedOptions.locale.slice(0,5) + "-u-ca-" + Calendar}
+		else Locale = undefined}
+	else if (Calendar !== "") Locale = Locale + "-u-ca-" + Calendar;
+	switch (document.LocaleOptions.Presentation.value) {
+		case "long":
+			Options = {weekday : "long", day : "numeric", month : "long", year : "numeric", era : "long"};
+			break;
+		case "textCumWeek":
+			Options = {weekday : "long", day : "numeric", month: "long", year : "numeric", era : "short"};
+			break;
+		case "textSineWeek":
+			Options = {weekday : undefined, day : "numeric", month: "long", year : "numeric", era : "short"};
+			break;
+		case "short":
+			Options = {weekday : "short", day : "numeric", month: "short", year : "numeric", era : "narrow"};
+			break;	
+		case "numeric":
+			Options = {weekday : undefined, day : "numeric", month : "numeric", year : "numeric", era : "narrow"};
+		}
+	switch (Calendar) {	// Certain calendars do not give a proper result;
+		case "hebrew": valid = (convertDate.getJulianDay() > 347997); break;	// Computations are false before 1 Tisseri 1 AM
+		case "indian": valid = (convertDate.getJulianDay() > 1721425); break;	// Computations are false before 01/01/0001 (gregorian)
+		case "islamic":
+		case "islamic-rgsa": valid = (convertDate.getJulianDay() > 1948438); break; // Computations are false before Haegirian epoch
+		}
+	//	Re-write Julian Day, which depends on the Locale variable.
+	document.daycounter.julianday.value = convertDate.getJulianDay().toLocaleString(Locale);
+
+	//	Write date string. Catch error if navigator fails.
+
+	let myDisplay = document.getElementById("milesianDisplay");
+	try {
+		myDisplay.innerHTML = convertDate.toMilesianLocaleDateString(Locale,Options);	
+		myDisplay = document.getElementById("UnicodeString");
+		myDisplay.innerHTML = (valid ? convertDate.toLocaleDateString(Locale,Options) : "Calcul Unicode en erreur");
+		}
+	catch (e) {	// If attempt to write Milesian string failed: this is caused by out-of-range
+		myDisplay.innerHTML = "Calcul navigateur en erreur";
+		myDisplay = document.getElementById("UnicodeString");
+		myDisplay.innerHTML = "Calcul navigateur en erreur";
+		}
+	finally { return }
+}
+
+function setDateDisplay () { // Considering that convertDate time has been set to the desired date, this routine updates all form fields.
+
+	// Update Milesian CLDR display
+
+	let dateComponent;	// Result of date decomposition process
+	
+    //  Update Milesian Calendar - here we use Date properties
+	dateComponent = convertDate.getMilesianUTCDate();
+    document.milesian.year.value = dateComponent.year; 
+    document.milesian.monthname.value = dateComponent.month ; // Month value following JS habits: 0 to 11.
+    document.milesian.day.value = dateComponent.date;
+
+    //  Update Gregorian Calendar - using Date properties
+    document.gregorian.year.value = convertDate.getUTCFullYear();
+    document.gregorian.monthname.value = convertDate.getUTCMonth();
+    document.gregorian.day.value = convertDate.getUTCDate();		
+
+    //  Update Julian Calendar - using Date properties 
+	dateComponent = convertDate.getJulianUTCDate();
+    document.julian.year.value = dateComponent.year;
+    document.julian.monthname.value = dateComponent.month;
+    document.julian.day.value = dateComponent.date;
+
+    //  Update Republican Calendar - using Date properties
+	dateComponent = convertDate.getFrenchRevUTCDate();
+    document.republican.year.value = dateComponent.year;
+    document.republican.monthname.value = dateComponent.month;
+    document.republican.day.value = dateComponent.date;	
+
+	//  Update ISO week calendar - using its Date properties
+	dateComponent = convertDate.getIsoWeekCalUTCDate();
+	document.isoweeks.year.value = dateComponent.year;
+	document.isoweeks.week.value = dateComponent.week;
+	document.isoweeks.day.value = dateComponent.day;	
+
+	// Set Julian Day, taken from convertDate
+	let myLocale = document.LocaleOptions.Locale.value;
+	if (myLocale == "") myLocale = undefined;
+   	document.daycounter.julianday.value = convertDate.getJulianDay().toLocaleString(myLocale); // 
+	
+	// Compute Locale, Options, and Unicode string
+	
+	putStringOnOptions();
+	
+	// Set Milesian clock
+	let clock = document.querySelector("#clock3");
+	setSolarYearClockHands (clock, convertDate.getMilesianUTCDate().month, convertDate.getMilesianUTCDate().date);
+
+}
+
+function setDateToToday(){ // Self explanatory
+    convertDate = new Date(); // set new Date object.
+	convertDate.setUTCHours(12,0,0,0); 	// set to today at noon UTC, to an integer value of Julian Day.
+	setDateDisplay ();
+}
+	
+function calcIntJulianDay(){ // here, Julian Day is specified as an integer number. Insert with the suitable Date setter.
+	let j = (document.daycounter.julianday.value); // extract Julian Day, numeric value (not necessarily integer) expected.
+	j = j.replace(/\s/gi, ""); j = j.replace(/,/gi, "."); j = Number (j);	// Replace blank and decimal comma, then try to build number
+	if (! Number.isInteger(j)) alert (milesianAlertMsg("nonInteger") + '"' + document.daycounter.julianday.value + '"')
+		else {
+		convertDate.setTimeFromJulianDay (j);	// Convert into JulianDay, considering Time Zone is UTC (offset = 0) 
+		setDateDisplay ();
+		}
+}
+function calcIntISO() {
+	let day =  Math.round (document.isoweeks.day.value);
+	let week = Math.round (document.isoweeks.week.value);
+	let year =  Math.round (document.isoweeks.year.value);
+	if	( isNaN(day)  || isNaN (week) || isNaN (year))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.isoweeks.year.value + '" "' + document.isoweeks.week.value + '"')
+	else {
+		convertDate.setUTCTimeFromIsoWeekCal (year,week,day, 12, 0, 0, 0);
+		setDateDisplay ();
+		}
+}
+function calcIntMilesian() {
+	let day =  Math.round (document.milesian.day.value);
+	let month = document.milesian.monthname.value;
+	let year =  Math.round (document.milesian.year.value);
+	if	( isNaN(day)  || isNaN (year ))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.milesian.day.value + '" "' + document.milesian.year.value + '"')
+	else {		
+		convertDate.setUTCTimeFromMilesian (year, month, day, 12, 0, 0, 0); 
+		setDateDisplay ();
+		}
+}
+function calcIntGregorian() {
+	let day =  Math.round (document.gregorian.day.value);
+	let month = (document.gregorian.monthname.value);
+	let year =  Math.round (document.gregorian.year.value);
+	if	( isNaN(day)  || isNaN (year ))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.gregorian.day.value + '" "' + document.gregorian.year.value + '"')
+	else {
+		convertDate.setUTCFullYear(year, month, day, 12, 0, 0, 0); 
+		setDateDisplay ();
+		}
+}
+function calcIntJulian(){
+	let day =  Math.round(document.julian.day.value);
+	let month = new Number(document.julian.monthname.value); // month has to be a number.
+	let year =  Math.round(document.julian.year.value);
+	if	( isNaN(day)  || isNaN (year))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.julian.day.value + '" "' + document.julian.year.value + '"')
+	else {
+		convertDate.setUTCTimeFromJulianCalendar (year, month, day, 12, 0, 0, 0);
+		setDateDisplay ();
+		}
+}
+function calcIntFrenchRev(){
+	let day =  Math.round(document.republican.day.value);
+	let month = new Number(document.republican.monthname.value); // month has to be a number.
+	let year =  Math.round(document.republican.year.value);
+	if	( isNaN(day)  || isNaN (year))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.republican.day.value + '" "' + document.republican.year.value + '"')
+	else {
+		convertDate.setUTCTimeFromFrenchRev (year, month, day, 12, 0, 0, 0);
+		setDateDisplay ();
+		}
+}
+function SetDayOffset (sign) { // Choice here: the days are integer, all 24h, so local time may change making this operation
+	if (sign == undefined) sign = 1;	// Sign is either +1 or -1. Just in case it does not come as a parameter.
+	let days = Math.round (document.control.shift.value); // number of days to add or substract is in control panel
+		if (!Number.isInteger(days)) alert (milesianAlertMsg("nonInteger") + '"' + days + '"')
+	else { 
+		convertDate.setUTCDate (convertDate.getUTCDate()+ sign*days);
+		setDateDisplay();
+	}
+}

--- a/Date-Converter/DateConverter.js
+++ b/Date-Converter/DateConverter.js
@@ -71,8 +71,6 @@ function putStringOnOptions() { // get Locale, calendar indication and Options g
 		case "islamic":
 		case "islamic-rgsa": valid = (convertDate.getJulianDay() > 1948438); break; // Computations are false before Haegirian epoch
 		}
-	//	Re-write Julian Day, which depends on the Locale variable.
-	document.daycounter.julianday.value = convertDate.getJulianDay().toLocaleString(Locale);
 
 	//	Write date string. Catch error if navigator fails.
 
@@ -80,12 +78,12 @@ function putStringOnOptions() { // get Locale, calendar indication and Options g
 	try {
 		myDisplay.innerHTML = convertDate.toMilesianLocaleDateString(Locale,Options);	
 		myDisplay = document.getElementById("UnicodeString");
-		myDisplay.innerHTML = (valid ? convertDate.toLocaleDateString(Locale,Options) : "Calcul Unicode en erreur");
+		myDisplay.innerHTML = (valid ? convertDate.toLocaleDateString(Locale,Options) : milesianAlertMsg("invalidDate"));
 		}
 	catch (e) {	// If attempt to write Milesian string failed: this is caused by out-of-range
-		myDisplay.innerHTML = "Calcul navigateur en erreur";
+		myDisplay.innerHTML = milesianAlertMsg("invalidDate");
 		myDisplay = document.getElementById("UnicodeString");
-		myDisplay.innerHTML = "Calcul navigateur en erreur";
+		myDisplay.innerHTML = milesianAlertMsg("invalidDate");
 		}
 	finally { return }
 }
@@ -125,14 +123,13 @@ function setDateDisplay () { // Considering that convertDate time has been set t
 	document.isoweeks.week.value = dateComponent.week;
 	document.isoweeks.day.value = dateComponent.day;	
 
+	// Compute Locale, Options, and Unicode string
+		putStringOnOptions();
+
 	// Set Julian Day, taken from convertDate
 	let myLocale = document.LocaleOptions.Locale.value;
 	if (myLocale == "") myLocale = undefined;
-   	document.daycounter.julianday.value = convertDate.getJulianDay().toLocaleString(myLocale); // 
-	
-	// Compute Locale, Options, and Unicode string
-	
-	putStringOnOptions();
+   	document.daycounter.julianday.value = convertDate.getJulianDay();
 	
 	// Set Milesian clock
 	let clock = document.querySelector("#clock3");
@@ -148,7 +145,7 @@ function setDateToToday(){ // Self explanatory
 	
 function calcIntJulianDay(){ // here, Julian Day is specified as an integer number. Insert with the suitable Date setter.
 	let j = (document.daycounter.julianday.value); // extract Julian Day, numeric value (not necessarily integer) expected.
-	j = j.replace(/\s/gi, ""); j = j.replace(/,/gi, "."); j = Number (j);	// Replace blank and decimal comma, then try to build number
+	j = j.replace(/\s/gi, ""); j = j.replace(/,/gi, "."); j = Number.parseInt (j,10);	// Extract integer of base 10
 	if (! Number.isInteger(j)) alert (milesianAlertMsg("nonInteger") + '"' + document.daycounter.julianday.value + '"')
 		else {
 		convertDate.setTimeFromJulianDay (j);	// Convert into JulianDay, considering Time Zone is UTC (offset = 0) 
@@ -213,7 +210,7 @@ function calcIntFrenchRev(){
 function SetDayOffset (sign) { // Choice here: the days are integer, all 24h, so local time may change making this operation
 	if (sign == undefined) sign = 1;	// Sign is either +1 or -1. Just in case it does not come as a parameter.
 	let days = Math.round (document.control.shift.value); // number of days to add or substract is in control panel
-		if (!Number.isInteger(days)) alert (milesianAlertMsg("nonInteger") + '"' + days + '"')
+	if (!Number.isInteger(days)) alert (milesianAlertMsg("nonInteger") + '"' + days + '"')
 	else { 
 		convertDate.setUTCDate (convertDate.getUTCDate()+ sign*days);
 		setDateDisplay();

--- a/Dial-clock/LightMilesianClock.html
+++ b/Dial-clock/LightMilesianClock.html
@@ -5,7 +5,7 @@
 	<meta content="text/html; charset=UTF-8" http-equiv="content-type"/>
 	<link href="milesian.css" rel="stylesheet"/>
 	<title>Horloge milésienne</title>
-	<script type="text/javascript" src="CalendarCycleComputationEngine.js"></script>
+	<script type="text/javascript" src="CBCCE.js"></script>
 	<script type="text/javascript" src="MilesianDateProperties.js"></script>
 	<script type="text/javascript" src="MilesianClockOperations.js"></script>
 </head>
@@ -22,7 +22,7 @@ var timeOutId1;					// Tick generator identifier
 function setLightClockToNow() {	// Set clock to present date and time
     let targetDate = new Date(); // targeDate is today and now.
 	let theClock = window.document.querySelector("#clock1"); 	// This object is the clock below. Do not call before clock loaded.
-	setSolarYearClockHands (theClock, targetDate.getMilesianDate().month, targetDate.getMilesianDate().date,
+	setSolarYearClockHands (theClock, targetDate.getMilesianDate().year, targetDate.getMilesianDate().month, targetDate.getMilesianDate().date,
 		targetDate.getHours(), targetDate.getMinutes(), targetDate.getSeconds() ); 
 }
 function setLightClockTicks() { // To be inserted on load of light clock
@@ -56,10 +56,7 @@ function setLightClockTicks() { // To be inserted on load of light clock
   <use xlink:href="#hourStroke" transform="rotate(300,0,-80)"/>
   <use xlink:href="#hourStroke" transform="rotate(330,0,-80)"/>
 <!-- am/pm indicator -->
-  <text class="ampm" style="
-	font-family	: Sans-Serif;
-	font-size	: 24px;
-	text-anchor	: middle;" 
+  <text class="clock ampm" 
 	x="0" y="-50">am</text>
 <!-- hours and minutes hands -->
   <g class="clockhand hour" transform="rotate(0)">
@@ -78,6 +75,9 @@ function setLightClockTicks() { // To be inserted on load of light clock
   opacity="0.8" >									
 	<line x1="0" x2="0" y1="0" y2="-200" stroke-width="8px"/>
   </g>
+<!-- the year field -->
+  <text class="clock yeardisplay"
+	x="0" y="+100"></text>
 <!-- center circle -->
 <circle class="clockhand" r="9" />
 </g>

--- a/Dial-clock/LightMilesianClock.svg
+++ b/Dial-clock/LightMilesianClock.svg
@@ -11,7 +11,7 @@ xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <title>Horloge milésienne</title>
-<script type="text/javascript" xlink:href="CalendarCycleComputationEngine.js"></script>
+<script type="text/javascript" xlink:href="CBCCE.js"></script>
 <script type="text/javascript" xlink:href="MilesianDateProperties.js"></script>
 <script type="text/javascript" xlink:href="MilesianClockOperations.js"></script>
 <script type="text/javascript">
@@ -19,7 +19,7 @@ var timeOutId1;					// Tick generator identifier
 function setLightClockToNow() {	// Set clock to present date and time
     let targetDate = new Date(); // targeDate is today and now.
 	let theClock = window.document.querySelector("#clock1"); 	// This object is the clock below. Do not call before clock loaded.
-	setSolarYearClockHands (theClock, targetDate.getMilesianDate().month, targetDate.getMilesianDate().date,
+	setSolarYearClockHands (theClock, targetDate.getMilesianDate().year, targetDate.getMilesianDate().month, targetDate.getMilesianDate().date,
 		targetDate.getHours(), targetDate.getMinutes(), targetDate.getSeconds() ); 
 }
 function setLightClockTicks() { // To be inserted on load of light clock
@@ -53,10 +53,7 @@ function setLightClockTicks() { // To be inserted on load of light clock
   <use xlink:href="#hourStroke" transform="rotate(300,0,-80)"/>
   <use xlink:href="#hourStroke" transform="rotate(330,0,-80)"/>
 <!-- am/pm indicator -->
-  <text class="ampm" style="
-	font-family	: Sans-Serif;
-	font-size	: 24px;
-	text-anchor	: middle;" 
+  <text class="clock ampm" 
 	x="0" y="-50">am</text>
 <!-- hours and minutes hands -->
   <g class="clockhand hour" transform="rotate(0)">
@@ -75,6 +72,9 @@ function setLightClockTicks() { // To be inserted on load of light clock
   opacity="0.8" >									
 	<line x1="0" x2="0" y1="0" y2="-200" stroke-width="8px"/>
   </g>
+<!-- the year field -->
+  <text class="clock yeardisplay"
+	x="0" y="+100"></text>
 <!-- center circle -->
 <circle class="clockhand" r="9" />
 </g>

--- a/Dial-clock/MilesianClock.html
+++ b/Dial-clock/MilesianClock.html
@@ -18,8 +18,8 @@
    <tbody>
 	 <form name="milesian" class="dateconvert" method="post" action="JavaScript:setClock();">
       <tr>
-        <td><input type="text" class="dateconvert" size="8" disabled="disabled" name="dayofweek"/> </td>
-        <td><input type="text" class="dateconvert" size="2" maxlength="3" name="day"/> </td>
+        <td><input name="dayofweek" type="text" class="dateconvert" size="8" disabled="disabled"/> </td>
+        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"></td>
         <td>
         <select name="monthname" size="1" class="dateconvert">
 		<option value="0">1m</option>
@@ -35,7 +35,7 @@
         <option value="10">11m</option>
         <option value="11">12m</option>
 		</select> </td>
-        <td><input type="text" class="dateconvert" size="5" maxlength="6" name="year" value="" type="text"/></td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
         <td><button class="dateconvert" name="Compute" value="milesian">Ok</button></td>
       </tr>
 	  <tr><td colspan="5" class="dateconvert">en grégorien proleptique (non julien):</td></tr>
@@ -46,31 +46,34 @@
   </tbody>
 </table>
 <table class="dateconvert" align="center"> <tbody>
-  <tr>
-  	<th colspan=2>Heure</th>
-	<td colspan=2><form name="Now" class="dateconvert" method="post" action="Javascript:setDateToNow();" >
-    <button class="dateconvert" value="Now" name="Compute" >Maintenant</button></form></td>
-  </tr>
   <tr> 
 	<form name="time" class="dateconvert" method="post" action="JavaScript:setClock();">
-	 <td><input type="text" class="dateconvert" size="2" maxlength="3" name="hours">h</td>
-	 <td><input type="text" class="dateconvert" size="2" maxlength="3" name="mins">mn</td>
-	 <td><input type="text" class="dateconvert" size="2" maxlength="3" name="secs">s</td>
+	 <td><input name="hours" type="number" min="0" max="23" class="dateconvert daynum">h</td>
+	 <td><input name="mins" type="number" min="0" max="59" class="dateconvert daynum">mn</td>
+	 <td><input name="secs" type="number" min="0" max="59" class="dateconvert daynum">s</td>
 	 <td><button class="dateconvert" name="Compute" value="time_of_day">Ok</button></td>	
 	</form>
   </tr>
 </tbody></table>
 <table class="dateconvert" align="center"> <tbody>
   <tr>
+	<td colspan=4><form name="Now" class="dateconvert" method="post" action="Javascript:setDateToNow();" >
+    <button name="Compute" class="dateconvert" value="Now">Maintenant</button></form></td>
+  </tr>
+  <tr>
     <form name="control" class="dateconvert" method="post" action="Javascript:SetDayOffset();">
-    <td><button class="dateconvert"  name="Compute" value="shift">+/- jours</button></td>
-	<td><input class="dateconvert"  maxlength="8" size="7" name="shift" value="1"></td> 
+    <td>+/- jours</td>
+	<td><button name="to" value="-1" class="dateconvert" formaction="Javascript:SetDayOffset(-1);" >-</button></td>
+	<td><input name="shift" type="number" value="1" class="dateconvert yearnum"></td> 
+	<td><button name="to" value="+1" class="dateconvert" formaction="Javascript:SetDayOffset(1);">+</button></td>
     </form>
   </tr>
   <tr>
-	 <form name="UTCshift" class="dateconvert" method="post" action="JavaScript:addTime();">
-	 <td><button class="dateconvert" name="Compute" value="time_offset">+/- secondes</button></td>
-	 <td><input type="text" class="dateconvert" maxlength="7" size="7" name="time_offset" value="1"></td>
+	<form name="UTCshift" class="dateconvert" method="post" action="JavaScript:addTime();">
+	<td>+/- secondes</td>
+	<td><button name="to" value="-1" class="dateconvert" formaction="Javascript:addTime(-1);" >-</button></td>
+	<td><input name="shift" type="number" value="1" class="dateconvert yearnum"></td>
+	<td><button name="to" value="+1" class="dateconvert" formaction="Javascript:addTime(1);">+</button></td>
 	</form>
   </tr>
 </tbody></table>

--- a/Dial-clock/MilesianClock.html
+++ b/Dial-clock/MilesianClock.html
@@ -4,80 +4,26 @@
 <html><head>
 	<meta content="text/html; charset=UTF-8" http-equiv="content-type"/>
 	<link href="milesian.css" rel="stylesheet"/>
-	<title>Horloge milésienne en jours et heures</title>
-	<script type="text/javascript" src="CalendarCycleComputationEngine.js"></script>
+	<title>Horloge milésienne</title>
+	
+<!-- ligne à retirer si lecture de milesianMonthNames.xml --><script type="text/javascript" src="milesianMonthNamesString.js"></script>
+	<script type="text/javascript" src="CBCCE.js"></script>
 	<script type="text/javascript" src="MilesianDateProperties.js"></script>
+	<script type="text/javascript" src="IsoWeekCalendarDateProperties.js"></script>
+	<script type="text/javascript" src="JulianDateProperties.js"></script>
+	<script type="text/javascript" src="FrenchRevDateProperties.js"></script>
+	<script type="text/javascript" src="LunarDateProperties.js"></script>
 	<script type="text/javascript" src="MilesianClockOperations.js"></script>
-	<script type="text/javascript" src="MilesianClockDisplay.js"></script>
     <script type="text/javascript" src="MilesianAlertMsg.js"></script>
+    <script type="text/javascript" src="toMilesianString.js"></script>
+    <script type="text/javascript" src="ChronologicalCountConversion.js"></script>
+	
+	<script type="text/javascript" src="MilesianClockDisplay.js"></script>
 
 </head>
 <body>
-<h1 class="dateconvert">Horloge milésienne en jours et heures</h1>
- <table class="dateconvert" align="center">
-   <tbody>
-	 <form name="milesian" class="dateconvert" method="post" action="JavaScript:setClock();">
-      <tr>
-        <td><input name="dayofweek" type="text" class="dateconvert" size="8" disabled="disabled"/> </td>
-        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"></td>
-        <td>
-        <select name="monthname" size="1" class="dateconvert">
-		<option value="0">1m</option>
-        <option value="1">2m</option>
-        <option value="2">3m</option>
-        <option value="3">4m</option>
-        <option value="4">5m</option>
-        <option value="5">6m</option>
-        <option value="6">7m</option>
-        <option value="7">8m</option>
-        <option value="8">9m</option>
-        <option value="9">10m</option>
-        <option value="10">11m</option>
-        <option value="11">12m</option>
-		</select> </td>
-        <td><input name="year" type="number" class="dateconvert yearnum"></td>
-        <td><button class="dateconvert" name="Compute" value="milesian">Ok</button></td>
-      </tr>
-	  <tr><td colspan="5" class="dateconvert">en grégorien proleptique (non julien):</td></tr>
-	  <tr>
-		<td colspan="5"><input type="text" class="dateconvert" size="40" disabled="disabled" name="gregoriandate"/> </td>
-	  </tr>
-	</form>
-  </tbody>
-</table>
-<table class="dateconvert" align="center"> <tbody>
-  <tr> 
-	<form name="time" class="dateconvert" method="post" action="JavaScript:setClock();">
-	 <td><input name="hours" type="number" min="0" max="23" class="dateconvert daynum">h</td>
-	 <td><input name="mins" type="number" min="0" max="59" class="dateconvert daynum">mn</td>
-	 <td><input name="secs" type="number" min="0" max="59" class="dateconvert daynum">s</td>
-	 <td><button class="dateconvert" name="Compute" value="time_of_day">Ok</button></td>	
-	</form>
-  </tr>
-</tbody></table>
-<table class="dateconvert" align="center"> <tbody>
-  <tr>
-	<td colspan=4><form name="Now" class="dateconvert" method="post" action="Javascript:setDateToNow();" >
-    <button name="Compute" class="dateconvert" value="Now">Maintenant</button></form></td>
-  </tr>
-  <tr>
-    <form name="control" class="dateconvert" method="post" action="Javascript:SetDayOffset();">
-    <td>+/- jours</td>
-	<td><button name="to" value="-1" class="dateconvert" formaction="Javascript:SetDayOffset(-1);" >-</button></td>
-	<td><input name="shift" type="number" value="1" class="dateconvert yearnum"></td> 
-	<td><button name="to" value="+1" class="dateconvert" formaction="Javascript:SetDayOffset(1);">+</button></td>
-    </form>
-  </tr>
-  <tr>
-	<form name="UTCshift" class="dateconvert" method="post" action="JavaScript:addTime();">
-	<td>+/- secondes</td>
-	<td><button name="to" value="-1" class="dateconvert" formaction="Javascript:addTime(-1);" >-</button></td>
-	<td><input name="shift" type="number" value="1" class="dateconvert yearnum"></td>
-	<td><button name="to" value="+1" class="dateconvert" formaction="Javascript:addTime(1);">+</button></td>
-	</form>
-  </tr>
-</tbody></table>
 <div class="dateconvert">
+<h1 class="dateconvert">Horloge milésienne</h1>
 <!-- put svg code inline -->
 <!-- Scalable viewbox, centered in the middle -->
 <svg width="300" height="100%" xml:lang="fr" onload="JavaScript:setDateToNow()"
@@ -109,10 +55,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
   <use xlink:href="#hourStroke" transform="rotate(300,0,-80)"/>
   <use xlink:href="#hourStroke" transform="rotate(330,0,-80)"/>
 <!-- am/pm indicator -->
-  <text class="ampm" style="
-	font-family	: Sans-Serif;
-	font-size	: 24px;
-	text-anchor	: middle;" 
+  <text class="clock ampm"
 	x="0" y="-50">am</text>
 <!-- hours and minutes hands -->
   <g class="clockhand hour" transform="rotate(0)">
@@ -131,10 +74,371 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
   opacity="0.8" >									
 	<line x1="0" x2="0" y1="0" y2="-200" stroke-width="8px"/>
   </g>
+<!-- the year field -->
+  <text class="clock yeardisplay"
+	x="0" y="+100"></text>
 <!-- center circle -->
 <circle class="clockhand" r="9" />
 </g>
 </svg>
+<table class="dateconvert" align="center">
+    <tr>	<th id="milesiandate" colspan="6"></th>	  </tr>
+</table>
+<table class="dateconvert" align="center">
+	 <form name="milesian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcMilesian();">
+	 <tr>
+        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"></td>
+        <td>
+        <select name="monthname" size="1" class="dateconvert">
+		<option value="0">1m</option>
+        <option value="1">2m</option>
+        <option value="2">3m</option>
+        <option value="3">4m</option>
+        <option value="4">5m</option>
+        <option value="5">6m</option>
+        <option value="6">7m</option>
+        <option value="7">8m</option>
+        <option value="8">9m</option>
+        <option value="9">10m</option>
+        <option value="10">11m</option>
+        <option value="11">12m</option>
+		</select> </td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
+        <td><button class="dateconvert">Ok</button></td>
+      </tr>
+	 </form>
+  </tbody>
+</table>
+<table class="dateconvert" align="center"> <tbody>
+  <tr> 
+	<form name="time" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcTime();">
+	 <td><input name="hours" type="number" min="0" max="23" class="dateconvert daynum">h</td>
+	 <td><input name="mins" type="number" min="0" max="59" class="dateconvert daynum">mn</td>
+	 <td><input name="secs" type="number" min="0" max="59" class="dateconvert daynum">s</td>
+	 <td><button class="dateconvert">Ok</button></td>	
+	</form>
+  </tr>
+</tbody></table>
+<table class="dateconvert" align="center">
+	<tr><td colspan="3">Date grégorienne équivalente</td></tr>
+	<tr>
+<!--	<td class="gregoriandate"></td> ici on mettait un clone Unicode, à éviter en raison de la gestion de l'heure locale -->
+		<form name="gregoriandate" class="dateconvert" autocomplete="off" method="post" action="JavaScript:void();">
+        <td><input name="day" type="text" disabled="disabled" class="dateconvert" size="2" maxlength="3"> </td>
+        <td><select name="monthname" disabled="disabled" class="dateconvert" size="1">
+        <option value="0">janvier</option>
+        <option value="1">février</option>
+        <option value="2">mars</option>
+        <option value="3">avril</option>
+        <option value="4">mai</option>
+        <option value="5">juin</option>
+        <option value="6">juillet</option>
+        <option value="7">août</option>
+        <option value="8">septembre</option>
+        <option value="9">octobre</option>
+        <option value="10">novembre</option>
+        <option value="11">décembre</option>
+        </select></td>
+        <td><input name="year" type="text" disabled="disabled" class="dateconvert" size="5" maxlength="6"> </td>
+  		</form>
+	</tr>
+</table>
 </div>
-<h3 class="dateconvert">© 2017-07 <a href="http://www.calendriermilesien.org">www.calendriermilesien.org</a></h3>
+<div class="dateconvert">
+<h1>Navigation</h1>
+ <table class="dateconvert" align="center"> <tbody> <tr>
+ 	<th>Heure UTC</th>
+	 <td class="UTCtime"></td>
+  </tr> </tbody></table>
+<table class="dateconvert" align="center">
+  <tr>
+	<form name="UTCset" class="dateconvert" method="post" action="JavaScript:setUTCHoursFixed();"> 
+	<td><button name="0h" class="dateconvert" formaction="JavaScript:setUTCHoursFixed(0)";>0h</button></td>
+	<td><button name="12h" class="dateconvert" formaction="JavaScript:setUTCHoursFixed(12)";>12h</button></td>
+	</form>
+	<td colspan=4><form name="Now" class="dateconvert" method="post" action="Javascript:setDateToNow();" >
+    <button class="dateconvert" >Maintenant</button></form></td>
+  </tr>
+  </table>
+<table class="dateconvert" align="center">
+  <tr>
+    <form name="control" class="dateconvert" method="post" action="Javascript:SetDayOffset();">
+    <td>+/- jours</td>
+	<td><button name="to" value="-1" class="dateconvert" formaction="Javascript:SetDayOffset(-1);" >-</button></td>
+	<td><input name="shift" type="number" value="1" class="dateconvert yearnum"></td> 
+	<td><button name="to" value="+1" class="dateconvert" formaction="Javascript:SetDayOffset(1);">+</button></td>
+    </form>
+  </tr>
+  <tr>
+	<form name="UTCshift" class="dateconvert" method="post" action="JavaScript:addTime();">
+	<td>+/- secondes</td>
+	<td><button name="to" value="-1" class="dateconvert" formaction="Javascript:addTime(-1);" >-</button></td>
+	<td><input name="shift" type="number" value="60" class="dateconvert yearnum"></td>
+	<td><button name="to" value="+1" class="dateconvert" formaction="Javascript:addTime(1);">+</button></td>
+	</form>
+  </tr>
+</tbody></table>
+</div>
+<div class="dateconvert autoscroll">
+<h1>Conversion de dates</h1>
+  <table class="dateconvert" align="center">
+   <tbody>
+      <tr>
+        <th>Cal.</th>
+        <th>Jour</th>
+        <th>Mois</th>
+        <th>Année</th>
+        <th></th>
+      </tr>
+      <tr>
+		<form name="gregorian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcGregorian();">
+        <td>G. </td>
+        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"> </td>
+        <td><select name="monthname" class="dateconvert" size="1">
+        <option value="0">janvier</option>
+        <option value="1">février</option>
+        <option value="2">mars</option>
+        <option value="3">avril</option>
+        <option value="4">mai</option>
+        <option value="5">juin</option>
+        <option value="6">juillet</option>
+        <option value="7">août</option>
+        <option value="8">septembre</option>
+        <option value="9">octobre</option>
+        <option value="10">novembre</option>
+        <option value="11">décembre</option>
+        </select></td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
+        <td><button name="Compute" value="gregorian" class="dateconvert">Ok</button></td>
+ 		</form>
+     </tr>	  
+      <tr>
+		<form name="julian" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcJulian();">
+        <td>J. </td>
+        <td><input name="day" type="number" min="1" max="31" class="dateconvert daynum"></td>
+        <td><select name="monthname" class="dateconvert" size="1">
+        <option value="0">janvier</option>
+        <option value="1">février</option>
+        <option value="2">mars</option>
+        <option value="3">avril</option>
+        <option value="4">mai</option>
+        <option value="5">juin</option>
+        <option value="6">juillet</option>
+        <option value="7">août</option>
+        <option value="8">septembre</option>
+        <option value="9">octobre</option>
+        <option value="10">novembre</option>
+        <option value="11">décembre</option>
+        </select></td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
+        <td><button name="Compute" value="julian" class="dateconvert">Ok</button> </td>
+ 		</form>
+     </tr>
+      <tr>
+		<form name="republican" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcFrenchRev();">
+        <td>R. </td>
+        <td><input name="day" type="number" min="1" max="30" class="dateconvert daynum"> </td>
+        <td><select name="monthname" class="dateconvert" size="1">
+        <option value="0">Vendémiaire</option>
+        <option value="1">Brumaire</option>
+        <option value="2">Frimaire</option>
+        <option value="3">Nivôse</option>
+        <option value="4">Pluviôse</option>
+        <option value="5">Ventôse</option>
+        <option value="6">Germinal</option>
+        <option value="7">Floréal</option>
+        <option value="8">Prairial</option>
+        <option value="9">Messidor</option>
+        <option value="10">Thermidor</option>
+        <option value="11">Fructidor</option>
+        <option value="12">Complément.</option>
+        </select></td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
+        <td><button name="Compute" value="republican" class="dateconvert">Ok</button> </td>
+ 		</form>
+     </tr>
+   </tbody>
+</table>
+  <table class="dateconvert" align="center">
+   <tbody>
+     <tr>
+        <th></th>
+        <th>Jour</th>
+        <th>Semaine</th>
+        <th>Année</th>
+        <th></th>
+      </tr>
+	<tr>
+		<form name="isoweeks" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcISO();">
+		<td>S. </td>
+		<td> 
+        <select name="day" class="dateconvert" size="1">
+		<option value="1">lundi</option>
+        <option value="2">mardi</option>
+        <option value="3">mercredi</option>
+        <option value="4">jeudi</option>
+        <option value="5">vendredi</option>
+        <option value="6">samedi</option>
+        <option value="7">dimanche</option>
+        </select></td>
+        <td><input name="week" type="number" class="dateconvert daynum"  min="1" max="53"> </td>
+        <td><input name="year" type="number" class="dateconvert yearnum"></td>
+        <td><button name="Compute" value="isoweeks" class="dateconvert">Ok</button> </td>
+	  </form>
+	</tr>
+   </tbody>
+ </table>
+<table class="dateconvert" align="center">
+  <tbody>
+    <form name="daycounter" class="dateconvert" autocomplete="off" method="post" action="JavaScript:calcJulianDay();">
+	<tr><th>Jour julien : </th><td></td>
+		<td><input name="julianday" type="text" value="1" class="dateconvert"></td>
+		<td><button name="setday" value="julianday" class="dateconvert">Ok</button></td>
+	</tr>
+	</form>
+  </tbody>
+</table>
+</div>
+<div class="dateconvert">
+<h1>Séries chronologiques</h1>
+	<table class="dateconvert" align="center">
+		<tr>
+			<th>Jour julien : </th>
+			<td id="jdDisplay"></td>
+		</tr>
+		<tr>
+			<th>Jour julien modifié : </th>
+			<td id="mjdDisplay"><td>
+		</tr>
+		<tr>
+			<th>Jour julien NASA : </th>
+			<td id="nasajdDisplay"><td>
+		</tr>
+		<tr>
+			<th>Jour Windows : </th>
+			<td id="windowsCountDisplay"></td>
+		</tr>
+		<tr>
+			<th>Jour MacOS : </th>
+			<td id="MacOSCountDisplay"></td>
+		</tr>
+		<tr>
+			<th>Compteur Unix : </th>
+			<td id="unixCountDisplay"></td>
+		</tr>
+	</table>
+</div>	
+<div class="dateconvert">
+<h1>Langues et calendriers Unicode</h1>
+	<table class="dateconvert" align="center"> <tbody>
+	<form name="LocaleOptions" class="dateconvert" method="post" action="JavaScript:setLocalePresentationCalendar();">
+		<tr><th> Langue </th><th> Format </th></tr>
+		<tr>
+			<td><input name="Locale" type="text" autocomplete="language" class="dateconvert" size="5"> </td>
+			<td>
+			<select name="Presentation" class="dateconvert" size="1">
+				<option value="long">long</option>
+				<option value="textCumWeek" selected>texte avec semaine</option>
+				<option value="textSineWeek">texte sans semaine</option>
+				<option value="short">abrégé</option>
+				<option value="numeric">numérique</option>
+			</select>
+			</td>
+		</tr>
+		<tr>
+			<th colspan="2"> Calendrier </th>
+		</tr>
+		<tr>
+			<td colspan="2">
+			<select name="Calendar" size="1" class="dateconvert">
+				<option value="">par défaut</option>
+				<option value="buddhist">bouddhiste Thaï</option>
+				<option value="chinese">chinois traditionnel</option>
+				<option value="coptic">copte</option>
+				<option value="dangi">coréen traditionnel</option>
+				<option value="ethioaa">éthiopien Amete Alem (5493 A.C.) </option>
+				<option value="ethiopic">éthiopien Amete Mihret (8 A.D.)</option>
+				<option value="gregory">grégorien (proleptique)</option>
+				<option value="hebrew">hébraïque</option>
+				<option value="indian">indien moderne</option>
+				<option value="islamic">islamique standard</option>
+				<option value="islamic-umalqura">islamique Umm al-Qura</option>
+				<option value="islamic-tbla">islamique tabulaire astronomique</option>
+				<option value="islamic-civil">islamique tabulaire civil</option>
+				<option value="islamic-rgsa">islamique, Arabie saoudite</option>
+				<option value="iso8601">grégorien avec règles ISO 8601</option>
+				<option value="japanese">japonais impérial</option>
+				<option value="persian">persan</option>
+				<option value="roc">chinois de république populaire</option>
+			</select> 
+			</td>
+		</tr>
+		<tr>
+			<td colspan="2"><button name="Compute" value="options" class="dateconvert">Ok</button></td>	
+	   </tr>
+   	</form></tbody></table>
+	<table class="dateconvert" align="center">
+		<tr><th>Date et heure Unicode</th></tr>
+		<tr><td id="UnicodeString"></td></tr>
+		<tr><th>Date milésienne</th></tr>
+		<tr><td id="milesianDisplay"></td></tr>
+	</table>
+</div>
+<div class="dateconvert">
+<h1 class="dateconvert">Données lunaires</h1>
+<form name="moon" class="dateconvert" method="post" action="JavaScript:void(0);">
+ <table class="dateconvert" align="center">
+ 	<tr><th colspan="4">Lune moyenne corrigée</th></tr>
+     <tr>
+		<th>Âge lunaire</th>	<th>Reliquat</th>   <th>Hauteur</th>  
+	 </tr>
+	 <tr>
+		<td><input name="age" value="" type="text" class="dateconvert" disabled="disabled" size="5"> </td>
+		<td><input name="residue" value="" type="text" class="dateconvert" disabled="disabled" size="5"> </td>
+		<td><input name="height" value="" type="text" class="dateconvert" disabled="disabled" size="5"> </td>
+	</tr>
+ </table>
+ <table class="dateconvert" align="center">
+	<tr><th>Heure lunaire (cycle des marées)</th><tr>
+	<tr>
+		<td><input name="moontime" value="" type="text" class="dateconvert" disabled="disabled" size="12"> </td>
+	</tr>
+	<tr><th>Date lunaire (hauteur de lune)</th></tr>
+	<tr>
+		<td><input name="moondate" value="" type="text" class="dateconvert" disabled="disabled" size="8"> </td>
+	</tr>
+ </table>
+ <table class="dateconvert" align="center">
+   <tbody>
+    <tr>
+	 <th colspan="4">Calendrier lunaire virtuel</th>
+	</tr>
+	<tr>
+	 <td>An 0:</td>
+	 <td><input name="CElunardate" value="" type="text" class="dateconvert" disabled="disabled" size="2"></td>
+	 <td><input name="CElunarmonth" value="" type="text" class="dateconvert" disabled="disabled" size="2"></td>
+	 <td><input name="CElunaryear" value="" type="text" class="dateconvert" disabled="disabled" size="6"></td>
+	</tr><tr>
+	 <td> Hégire:</td>
+	 <td><input name="hegiriandate" value="" type="text" class="dateconvert" disabled="disabled" size="2"></td>
+	 <td><input name="hegirianmonth" value="" type="text" class="dateconvert" disabled="disabled" size="2"></td>
+	 <td><input name="hegirianyear" value="" type="text" class="dateconvert" disabled="disabled" size="6"></td>
+	</tr>
+  </tbody>
+ </table> 
+</form>
+<br>
+<table class="dateconvert" align="center">
+  <tbody>
+ 	<tr><th colspan="2">Estimation de Delta T (UTC = TT - Delta T)</th></tr>
+     <tr>
+		<form name="deltat" class="dateconvert" method="post" action="JavaScript:void(0);">
+		<td>Delta T (secondes):</td>
+		<td><input type="text" class="dateconvert" disabled="disabled" size="15" name="delta"> </td>
+		</form>
+	</tr>
+  </tbody>
+</table>
+</div>
+<h3 class="dateconvert">© 2017-12 <a href="http://www.calendriermilesien.org">www.calendriermilesien.org</a></h3>
 </body></html>

--- a/Dial-clock/MilesianClock.html
+++ b/Dial-clock/MilesianClock.html
@@ -148,7 +148,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
 <h1>Navigation</h1>
  <table class="dateconvert" align="center"> <tbody> <tr>
  	<th>Heure UTC</th>
-	 <td class="UTCtime"></td>
+	 <td id="UTCtime"></td>
   </tr> </tbody></table>
 <table class="dateconvert" align="center">
   <tr>

--- a/Dial-clock/MilesianClockDisplay.js
+++ b/Dial-clock/MilesianClockDisplay.js
@@ -27,43 +27,187 @@
 //	MilesianClockOperations
 //	MilesianDateProperties
 //
-var targetDate = new Date() ; // target date will be used to update everything
+var 
+	targetDate = new Date(); // target date will be used to update everything
 
-function setDisplay () {	// Disseminate targetDate on all display
-    document.milesian.dayofweek.value = targetDate.toLocaleDateString(undefined,{weekday:"long"});
-	document.milesian.year.value = targetDate.getMilesianDate().year; // uses the local variable - not UTC
-    document.milesian.monthname.value = targetDate.getMilesianDate().month ; // Month value following JS habits: 0 to 11.
-    document.milesian.day.value = targetDate.getMilesianDate().date;
-	document.milesian.gregoriandate.value = targetDate.toLocaleDateString
-		(undefined,{weekday:"long",day:"numeric",month:"long",year:"numeric",era:"narrow"});
+function setDisplay () {	// Disseminate targetDate and time on all display
+
+	let dateComponent;	// Local result of date decomposition process, used several times
+
+	// Initiate milesian clock and milesian string with present time and date
+	let myElement = document.querySelector("#clock2");
+	setSolarYearClockHands (myElement, targetDate.getMilesianDate().year, targetDate.getMilesianDate().month, targetDate.getMilesianDate().date,
+		targetDate.getHours(), targetDate.getMinutes(), targetDate.getSeconds() );
+		
+	// Locale value for the next statements - not used anymore (because of Edge)
+/*	let Locale = document.LocaleOptions.Locale.value; 
+	if (Locale == "") Locale = undefined; 
+*/
+
+	// Display Gregorian date in non-editable part
+	myElement = document.gregoriandate;
+	myElement.year.value = targetDate.getFullYear();
+	myElement.monthname.value = targetDate.getMonth();
+	myElement.day.value = targetDate.getDate();
+		
+	// Display UTC time
+	myElement = document.querySelector(".UTCtime");
+	myElement.innerHTML = 
+	  targetDate.getUTCHours() + "h "
+	  + ((targetDate.getUTCMinutes() < 10) ? "0" : "") + targetDate.getUTCMinutes() + "mn " 
+	  + ((targetDate.getUTCSeconds() < 10) ? "0" : "") + targetDate.getUTCSeconds() + "s";
+	// This variant makes a bug with MS Edge, if outside the range of handled values :
+	/*	targetDate.toLocaleTimeString
+		(Locale,{timeZone: "UTC", hour12: false}); */
+	
+	// Update local time fields - using	Date properties
 	document.time.hours.value = targetDate.getHours();
 	document.time.mins.value = targetDate.getMinutes();
 	document.time.secs.value = targetDate.getSeconds();
-	let clock = document.querySelector("#clock2");
-	setSolarYearClockHands (clock, targetDate.getMilesianDate().month, targetDate.getMilesianDate().date,
-		targetDate.getHours(), targetDate.getMinutes(), targetDate.getSeconds() );
+
+	// Update milesian field selector - using Date properties
+	dateComponent = targetDate.getMilesianDate();		// Get date-time component in local time
+	document.milesian.year.value = dateComponent.year;
+    document.milesian.monthname.value = dateComponent.month;
+    document.milesian.day.value = dateComponent.date;
+	
+    //  Update Gregorian Calendar - using Date properties
+    document.gregorian.year.value = targetDate.getFullYear();
+    document.gregorian.monthname.value = targetDate.getMonth();
+    document.gregorian.day.value = targetDate.getDate();		
+
+    //  Update Julian Calendar - using Date properties 
+	dateComponent = targetDate.getJulianDate();
+    document.julian.year.value = dateComponent.year;
+    document.julian.monthname.value = dateComponent.month;
+    document.julian.day.value = dateComponent.date;
+
+    //  Update Republican Calendar - using Date properties
+	dateComponent = targetDate.getFrenchRevDate();
+    document.republican.year.value = dateComponent.year;
+    document.republican.monthname.value = dateComponent.month;
+    document.republican.day.value = dateComponent.date;	
+
+	//  Update ISO week calendar - using its Date properties
+	dateComponent = targetDate.getIsoWeekCalDate();
+	document.isoweeks.year.value = dateComponent.year;
+	document.isoweeks.week.value = dateComponent.week;
+	document.isoweeks.day.value = dateComponent.day;	
+
+	// Set Julian Day, taken from targetDate
+   	document.daycounter.julianday.value = targetDate.getJulianDay();
+	
+	// Display chronological counts
+	myElement = document.querySelector("#unixCountDisplay");
+	myElement.innerHTML = targetDate.valueOf();
+	myElement = document.querySelector("#jdDisplay");
+	myElement.innerHTML = targetDate.getCount("julianDay").toLocaleString(undefined,{maximumFractionDigits:6});
+	myElement = document.querySelector("#mjdDisplay");
+	myElement.innerHTML = targetDate.getCount("modifiedJulianDay").toLocaleString(undefined,{maximumFractionDigits:6});
+	myElement = document.querySelector("#nasajdDisplay");
+	myElement.innerHTML = targetDate.getCount("nasaDay").toLocaleString(undefined,{maximumFractionDigits:6});
+	myElement = document.querySelector("#windowsCountDisplay");
+	myElement.innerHTML = targetDate.getCount("windowsCount").toLocaleString(undefined,{maximumFractionDigits:6});
+	myElement = document.querySelector("#MacOSCountDisplay");
+	myElement.innerHTML = targetDate.getCount("macOSCount").toLocaleString(undefined,{maximumFractionDigits:6});
+
+	// Update lunar parameters - using targetDate
+	dateComponent = targetDate.getCEMoonDate();
+	document.moon.age.value = dateComponent.age.toLocaleString(undefined,{maximumFractionDigits:2, minimumFractionDigits:2}); // age given as a decimal number
+	document.moon.residue.value = (29.5305888310185 - dateComponent.age).toLocaleString(undefined,{maximumFractionDigits:2, minimumFractionDigits:2});
+	document.moon.height.value = targetDate.getDraconiticHeight().toLocaleString(undefined,{maximumFractionDigits:3, minimumFractionDigits:3});
+	document.moon.moontime.value = targetDate.getLunarTime().hours + "h " 
+				+  ((targetDate.getLunarTime().minutes < 10) ? "0" : "") + targetDate.getLunarTime().minutes + "mn "
+				+  ((targetDate.getLunarTime().seconds < 10) ? "0" : "") + targetDate.getLunarTime().seconds + "s";
+	document.moon.moondate.value = targetDate.getLunarDateTime().date + " " 
+				+  (++targetDate.getLunarDateTime().month) + "m";
+	document.moon.CElunardate.value = 	Math.ceil(dateComponent.age);
+	document.moon.CElunarmonth.value = 	++dateComponent.month
+	document.moon.CElunaryear.value = 	dateComponent.year
+	dateComponent = targetDate.getHegirianMoonDate();	
+	document.moon.hegiriandate.value = 	Math.ceil(dateComponent.age);
+	document.moon.hegirianmonth.value = ++dateComponent.month
+	document.moon.hegirianyear.value = 	dateComponent.year
+	
+	// Update Delta T (seconds)
+	document.deltat.delta.value = (targetDate.getDeltaT()/Chronos.SECOND_UNIT); // 
+
+	// Display date string, following options
+	putStringOnOptions();				
+
 }
-function setClock() {			// Extract day and month from display, then compute clock hands positions
-	let 
-		year =  Math.round (document.milesian.year.value),
-		month = document.milesian.monthname.value,
-		day =  Math.round (document.milesian.day.value),
-		hour = Math.round (document.time.hours.value),
-		minute = Math.round (document.time.mins.value),
-		second = Math.round (document.time.secs.value);
-	if	( isNaN (year ) || isNaN(day) || isNaN(hour) || isNaN(minute) || isNaN(second))
-		alert (milesianAlertMsg("invalidDate") + '"'  
-		+ document.milesian.day.value + '" "' + document.milesian.year.value + '" "'
-		+ document.time.hours.value + '" "' + document.time.mins.value + '" "' + document.time.secs.value + '"')
-	else {		
-		targetDate.setTimeFromMilesian (year, month, day); // Set date object from milesian date indication, without changing time-in-the-day.
-		targetDate.setHours (hour, minute, second); // Set time in date object from given time.
-		setDisplay();
+function putStringOnOptions() { // get Locale, calendar indication and Options given on page, print String; No control.
+	let valid = true; 	// by default, computations under Unicode are expected valid. Certains cases are known false.
+
+	// Negotiate effective Locale from specified language code and calendar
+	let Locale = document.LocaleOptions.Locale.value;
+	let Calendar = document.LocaleOptions.Calendar.value;
+	let Options; 		// to be computed later;
+	
+	if (Locale == ""){ 	// no language code specified; in case a specific calendar is specified, construct an effectice Locale.
+		if (Calendar !== "") {
+			let askedOptions = new Intl.DateTimeFormat ();
+			let usedOptions = askedOptions.resolvedOptions();
+			Locale = usedOptions.locale.slice(0,5) + "-u-ca-" + Calendar}
+		else Locale = undefined}
+	else if (Calendar !== "") Locale = Locale + "-u-ca-" + Calendar;
+	
+	// Set presentation options from one of the standard presentation listed
+	switch (document.LocaleOptions.Presentation.value) {
+		case "long":
+			Options = {weekday : "long", day : "numeric", month : "long", year : "numeric", era : "long"};
+			break;
+		case "textCumWeek":
+			Options = {weekday : "long", day : "numeric", month: "long", year : "numeric", era : "short"};
+			break;
+		case "textSineWeek":
+			Options = {weekday : undefined, day : "numeric", month: "long", year : "numeric", era : "short"};
+			break;
+		case "short":
+			Options = {weekday : "short", day : "numeric", month: "short", year : "numeric", era : "narrow"};
+			break;	
+		case "numeric":
+			Options = {weekday : undefined, day : "numeric", month : "numeric", year : "numeric", era : "narrow"};
 		}
+	
+	
+	switch (Calendar) {	// Certain calendars do not give a proper result;
+		case "hebrew": valid = (targetDate.valueOf()-targetDate.getTimezoneOffset() * Chronos.MINUTE_UNIT 
+			>= -180799776000000); break;	// Computations are false before 1 Tisseri 1 AM  	
+		case "indian": valid = (targetDate.valueOf()-targetDate.getTimezoneOffset() * Chronos.MINUTE_UNIT 
+			>= -62135596800000); break;	// Computations are false before 01/01/0001 (gregorian)
+		case "islamic":
+		case "islamic-rgsa": valid = (targetDate.valueOf()-targetDate.getTimezoneOffset() * Chronos.MINUTE_UNIT
+			>= -42521673600000); break; // Computations are false before Haegirian epoch
+		}
+
+	//	Write date string. Catch error if navigator fails.
+
+	let myDisplay = document.getElementById("milesiandate");	// First write error message under the main clock, then write date if no problem.
+	myDisplay.innerHTML = milesianAlertMsg("invalidDate");	
+	
+	try {
+		myDisplay = document.getElementById("milesianDisplay");
+		myDisplay.innerHTML = targetDate.toMilesianLocaleDateString(Locale,Options);	
+		myDisplay = document.getElementById("milesiandate");
+		myDisplay.innerHTML = targetDate.toMilesianLocaleDateString
+			(Locale,{weekday:"long",day:"numeric",month:"long",year:"numeric"});
+		myDisplay = document.getElementById("UnicodeString");
+		myDisplay.innerHTML = (valid ? targetDate.toLocaleTimeString(Locale,Options) : milesianAlertMsg("invalidDate"));
+		}
+	catch (e) {	// If attempt to write Milesian string failed: this is caused by out-of-range
+		myDisplay.innerHTML = milesianAlertMsg("invalidDate");
+		myDisplay = document.getElementById("UnicodeString");
+		myDisplay.innerHTML = milesianAlertMsg("invalidDate");
+		}
+	finally { return }
 }
 function setDateToNow(){ // Self explanatory
     targetDate = new Date(); // set new Date object.
 	setDisplay();
+}
+function setLocalePresentationCalendar() {	// What happens when Locale-presentation-calendar option button hit
+	setDisplay();	// set all, as Locale may change the way the first Milesian string is written
 }
 function SetDayOffset (sign) { // Choice here: the days are integer, all 24h, so local time may change making this operation
 	if (sign == undefined) sign = 1;	// Sign is either +1 or -1. Just in case it does not come as a parameter.
@@ -82,4 +226,85 @@ function addTime (sign) { // A number of seconds is added or substracted to or f
 		targetDate.setTime (targetDate.getTime()+sign*secs*Chronos.SECOND_UNIT);
 		setDisplay();
 	}
+}
+function calcTime() { // Here the hours are deemed local hours
+	var hours = Math.round (document.time.hours.value), mins = Math.round (document.time.mins.value), secs = Math.round (document.time.secs.value);
+	if (isNaN(hours) || isNaN (mins) || isNaN (secs)) 
+		alert (milesianAlertMsg("invalidDate") + '"' + document.time.hours.value + '" "' + document.time.mins.value + '" "' + document.time.secs.value + '"')
+	 else {
+		targetDate.setHours(hours, mins, secs, 0); 
+		// targetDate.setMinutes(mins); targetDate.setSeconds(secs); targetDate.setMilliseconds(0); Before Javascript 1.3
+		setDisplay();	
+	}
+}
+function setUTCHoursFixed (UTChours=0) { // set UTC time to the hours sepcified.
+		if (typeof UTChours == undefined)  UTChours = document.UTCset.Compute.value;
+		targetDate.setUTCHours(UTChours, 0, 0, 0); //targetDate.setUTCMinutes(0); targetDate.setSeconds(0); targetDate.setMilliseconds(0);
+		setDisplay();	
+}
+function calcMilesian() {
+	var day =  Math.round (document.milesian.day.value);
+	var month = document.milesian.monthname.value;
+	var year =  Math.round (document.milesian.year.value);
+	if	( isNaN(day)  || isNaN (year ))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.milesian.day.value + '" "' + document.milesian.year.value + '"')
+	else {		
+		targetDate.setTimeFromMilesian (year, month, day); // Set date object from milesian date indication, without changing time-in-the-day.
+		setDisplay ();
+		}
+}
+function calcJulianDay(){ // here, Julian Day is specified as a decimal number. Insert with the suitable Date setter.
+	var j = (document.daycounter.julianday.value); // extract Julian Day, numeric value (not necessarily integer) expected.
+	j = j.replace(/\s/gi, ""); j = j.replace(/,/gi, "."); j = Number (j);
+	if (isNaN (j)) alert (milesianAlertMsg("nonNumeric") + '"' + document.daycounter.julianday.value + '"')
+	else {
+		j =  Math.round ((j * Chronos.DAY_UNIT)/Chronos.SECOND_UNIT) * Chronos.SECOND_UNIT / Chronos.DAY_UNIT ; 
+		// j rounded to represent an integer number of seconds, avoiding rounding up errors.
+	targetDate.setTimeFromJulianDay (j); 
+	setDisplay ();
+	}
+}
+function calcGregorian() {
+	var day =  Math.round (document.gregorian.day.value);
+	var month = (document.gregorian.monthname.value);
+	var year =  Math.round (document.gregorian.year.value);
+	if	( isNaN(day)  || isNaN (year ))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.gregorian.day.value + '" "' + document.gregorian.year.value + '"')
+	else {
+		targetDate.setFullYear(year, month, day); 	// Set date object from gregorian date indication, without changing time-in-the-day.
+		setDisplay ();
+		}
+}
+function calcJulian(){
+	var day =  Math.round(document.julian.day.value);
+	var month = new Number(document.julian.monthname.value); // month has to be a number.
+	var year =  Math.round(document.julian.year.value);
+	if	( isNaN(day)  || isNaN (year))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.julian.day.value + '" "' + document.julian.year.value + '"')
+	else {
+		targetDate.setTimeFromJulianCalendar (year, month, day);
+		setDisplay ();
+		}
+}
+function calcFrenchRev(){
+	let day =  Math.round(document.republican.day.value);
+	let month = new Number(document.republican.monthname.value); // month has to be a number.
+	let year =  Math.round(document.republican.year.value);
+	if	( isNaN(day)  || isNaN (year))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.republican.day.value + '" "' + document.republican.year.value + '"')
+	else {
+		targetDate.setTimeFromFrenchRev (year, month, day);
+		setDisplay ();
+		}
+}
+function calcISO() {
+	var day =  Math.round (document.isoweeks.day.value);
+	var week = Math.round (document.isoweeks.week.value);
+	var year =  Math.round (document.isoweeks.year.value);
+	if	( isNaN(day)  || isNaN (week) || isNaN (year))
+		alert (milesianAlertMsg("invalidDate") + '"' + document.isoweeks.year.value + '" "' + document.isoweeks.week.value + '"')
+	else {
+		targetDate.setTimeFromIsoWeekCal (year,week,day);
+		setDisplay ();
+		}
 }

--- a/Dial-clock/MilesianClockDisplay.js
+++ b/Dial-clock/MilesianClockDisplay.js
@@ -65,21 +65,21 @@ function setDateToNow(){ // Self explanatory
     targetDate = new Date(); // set new Date object.
 	setDisplay();
 }
-function SetDayOffset () { // Choice here: the days are integer, all 24h, so local time may change making this operation
-	var days = Math.round (document.control.shift.value);
-	if (isNaN(days)) alert (milesianAlertMsg("nonInteger") + '"' + document.control.shift.value + '"')
+function SetDayOffset (sign) { // Choice here: the days are integer, all 24h, so local time may change making this operation
+	if (sign == undefined) sign = 1;	// Sign is either +1 or -1. Just in case it does not come as a parameter.
+	let days = Math.round (document.control.shift.value);
+	if (!Number.isInteger(days)) alert (milesianAlertMsg("nonInteger") + '"' + days + '"')
 	else { 
-		document.control.shift.value = days;
-		targetDate.setUTCDate (targetDate.getUTCDate()+days);
+		targetDate.setUTCDate (targetDate.getUTCDate()+sign*days);
 		setDisplay();
 	}
 }
-function addTime () { // A number of seconds is added (minus also possible) to the Timestamp.
-	var secs = Math.round (document.UTCshift.time_offset.value);
-	if (isNaN(secs)) alert (milesianAlertMsg("nonInteger") + '"' + document.UTCshift.time_offset.value + '"')
+function addTime (sign) { // A number of seconds is added or substracted to or from the Timestamp.
+	if (sign == undefined) sign = 1;	// Sign is either +1 or -1. Just in case it does not come as a parameter.
+	let secs = Math.round (document.UTCshift.shift.value);
+	if (isNaN(secs)) alert (milesianAlertMsg("nonInteger") + '"' + document.UTCshift.shift.value + '"')
 	else { 
-		document.UTCshift.time_offset.value = secs;
-		targetDate.setTime (targetDate.getTime()+secs*Chronos.SECOND_UNIT);
+		targetDate.setTime (targetDate.getTime()+sign*secs*Chronos.SECOND_UNIT);
 		setDisplay();
 	}
 }

--- a/Dial-clock/MilesianClockOperations.js
+++ b/Dial-clock/MilesianClockOperations.js
@@ -4,6 +4,7 @@
 // may handle month, day, hour, minute and second hands. All hands do not need to exist.
 */////////////////////////////////////////////////////////////////////////////////////////////
 // Version 2, M2017-11-07: added an "am/pm" indicator
+// Version 3, M2017-12-26: added year indication, and changed params list
 /* Copyright Miletus 2017 - Louis A. de Fouquières
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -25,7 +26,7 @@
 // or the use or other dealings in the software.
 // Inquiries: www.calendriermilesien.org
 */
-function setSolarYearClockHands(clock, month = 0, day = 1, hour = 24, minute = 0, second = 0, continuous = false) { 
+function setSolarYearClockHands(clock, year = undefined, month = 0, day = 1, hour = 24, minute = 0, second = 0, continuous = false) { 
 //	On "clock" object, set all available hands (month, day, hour, minutes, seconds)
 //  Unless "continuous" is specified as true, set month and day hands at end of day.
 //  If no date given, set to 1 1m.
@@ -47,5 +48,7 @@ function setSolarYearClockHands(clock, month = 0, day = 1, hour = 24, minute = 0
 	}
 	let theAmPm = clock.querySelector(".ampm");			// Select the am/pm indicator, check whether existing.
 	if (theAmPm !== null) theAmPm.innerHTML = (hour > 11 ? "pm" : "am");	// hour is 0 to 23. "am" from 0 to 11, "pm" from 12 to 23.
+	let theYear = clock.querySelector(".yeardisplay");		// Select the year field, check whether existing.
+	if (theYear !== null) theYear.innerHTML = Number.isInteger(year) ? year : "" ;
 	return halfDays;	// control the computation parameters with the return value
 }

--- a/Milesian-Locale/toMilesianString.js
+++ b/Milesian-Locale/toMilesianString.js
@@ -1,11 +1,13 @@
 /* Milesian properties added to Date in order to generate date strings
 // Character set is UTF-8
 // This code, to be manually imported, set properties to object Date for the Milesian calendar, especially to generate date strings
+// Version M2017-12-28 catches MS Edge generated error
 // Version M2017-12-26 formal update of M2017-07-04 concerning dependent files
 //  toMilesianLocaleDateString ([locale, [options]]) : return a string with date and time, according to locale and options.
 // Necessary files:
 //	MilesianMonthNames.xml: fetched source of month names - may be provided by milesianMonthNamesString
 //	MilesianDateProperties.js (and dependent files)
+//	MilesianALertMsg
 */////////////////////////////////////////////////////////////////////////////////////////////
 /* Copyright Miletus 2016-2017 - Louis A. de Fouquières
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -48,43 +50,61 @@ function pad(number) {	// utility function, pad 2-digit integer numbers. No cont
 // This method is a makeup, the result is not totally in line with the expected results of such functions.
 // It just show that these layouts are possible.
 //////////////////////////////////////////////////////
+
 Date.prototype.toMilesianLocaleDateString = function (locales = undefined, options = undefined) {
-	if (milesianNames == undefined) return ""; else {	// if milesianNames not yet established, or not loaded, then skip
+
+	// if milesianNames not yet established, or not loaded, then return empty (may be this should by settled with an error)
+	if (milesianNames == undefined) return ""; else {	
+
+	// Initialise string parts
 	let str = ""; 	// the final string for this date;
 	let wstr = "", dstr = "", mstr = "", ystr = "" ; // components of date string
 //	let tstr = "", tzstr = ""; 	// components of time string. Not used.	
 	let wsep = " ", msep = " ", ysep = " ";	// separators of date elements, "/", ", " or " ".
+	
+	// Establish effective options through "negotiation"
 	if (options == undefined) var askedOptions = new Intl.DateTimeFormat (locales)	// require locale and option from present implementation;
 	else var askedOptions = new Intl.DateTimeFormat (locales, options); // Computed object from asked locales and options
 	var usedOptions = askedOptions.resolvedOptions(); // resolve options to use after "negotiation": 
 	// example of standard usedOptions: { locale: "fr-FR", calendar: "gregory", numberingSystem: "latn", timeZone: "Europe/Paris", day: "2-digit", month: "2-digit", year: "numeric" }
 	// while specifiying option, you may suppress year, month or day.
+	
+	// Get effective language and country, and set whether month should come before day
 	let lang = usedOptions.locale[0] + usedOptions.locale[1], country = usedOptions.locale[3] + usedOptions.locale[4]; // Decompose Locales string.
 	let monthDay = false;	// true for languages and countries where month comes before day.
-	let Xpath1 = "", node = undefined;	// will be used for searching the month's names in the Locale data registry
+	
 
 	// Compute weekday if desired. Computation does not trust toLocaleDateString, as TimezoneOffset may be lost.
 	if (usedOptions.weekday !== undefined) {
 		// toLocaleDateString takes a different timeZone into account that plain JS. So we build an UTC date corresponding to the timeZone date.
 		let LocalTime = new Date(); 
 		LocalTime.setTime(this.valueOf() - this.getTimezoneOffset() * Chronos.MINUTE_UNIT); // This time enables date computations as if the local time was UTC time.
-		wstr = LocalTime.toLocaleDateString ((lang+"-u-ca-gregory"), {timeZone : "UTC", weekday : usedOptions.weekday}); 
-			// construct weekday with asked language, but gregorian calendar
+		try {	// As MS Edge may throw a range error for any date before 0001-01-01, error is catched and wstr set to blank
+			// construct weekday with asked language, and in gregorian calendar
+			wstr = LocalTime.toLocaleDateString ((lang+"-u-ca-gregory"), {timeZone : "UTC", weekday : usedOptions.weekday}); 
+			}
+		catch (e) {
+			wstr = "";	// case of date range error: weekday set to blank, computations continue
 		}
+	}
 
 	// Compute year
 	switch (usedOptions.year) {	// Compute year string
 		case "numeric": ystr = this.getMilesianDate().year; break;
 		case "2-digit": ystr = this.getMilesianDate().year % 100; break;
 		default : break; }
+		
+	// Compute year separator
 	if (ystr !== "") switch (lang) {	// Language dependent year separator, if month is not numeric
 		case "en" : switch (country) { 	// Depending on English-speaking countries, a comma may be necessary
 			case "US" : case "CA" : ysep = ", "; monthDay = true; break;
 			default : ysep = " "; break
 			}; break;		
 		case "es" : case "pt" : ysep = " de "; break;
-		};
-	switch (usedOptions.month) {	// Compute separator between month and day, depending on month option.
+		}
+	
+	// Compute separator between month and day, depending on month option.
+	switch (usedOptions.month) {	
 		case "numeric": case "2-digit" : msep = "/"; break;
 		case "narrow": case "short" : case "long" : 
 			switch (lang) { 		// If month is not a numeric value, there a sign or text. Here we use shortcuts.
@@ -94,7 +114,10 @@ Date.prototype.toMilesianLocaleDateString = function (locales = undefined, optio
 			break;
 		default : break; }
 	if (msep == "/" && ysep !== "") ysep = "/"; // If there is a year element, and month element is numeric, year separator shall always be "/"
-	switch (usedOptions.month) {	// Compute month part of string 
+
+	// Compute month part of string 
+	let Xpath1 = "", node = undefined;	// will be used for searching the month's names in the Locale data registry
+	switch (usedOptions.month) {	
 //		case "numeric": mstr = this.getMilesianDate().month+1; break; That is the "easy" way, we do not use it. Numeric should give 1m, 2m etc, like "narrow".
 		case "2-digit": mstr = pad (this.getMilesianDate().month+1); break;
 		case "narrow":	// Only the international (Latin) value can be used in this case
@@ -121,24 +144,31 @@ Date.prototype.toMilesianLocaleDateString = function (locales = undefined, optio
 			if (node.stringValue !== "") mstr = node.stringValue; // If found, replace Latin name with language-dependant.
 			break;
 		default : break; }
-	switch (usedOptions.day) {	// Compute day string, a plain numeric or 2-digit string.
-		case "numeric": dstr = this.getMilesianDate().date; break;
+		
+	// Compute day string, a plain numeric or 2-digit string.	
+	switch (usedOptions.day) {	
+		case "numeric": dstr = this.getMilesianDate().date; break;	// no blank
 		case "2-digit": dstr = pad (this.getMilesianDate().date); break;
-		default : break; }	
+		default : break; }
+		
+//	Finally we do not compute the Time part, since it is a Date (only) function.
 /*	if (usedOptions.hour !== undefined || usedOptions.minute !== undefined || usedOptions.hour !== undefined) 
 		tstr = new Intl.DateTimeFormat (usedOptions.locale, {hour : usedOptions.hour, minute : usedOptions.minute, second : usedOptions.second}).format(this);
-//	Finally we do not compute the Time part, since it is a Date (only) function.
 */	
-	if (wstr !== "" && dstr !== "") switch (lang) {	//Compute weekday separator, which depends on language
+
+	//Compute weekday separator, which depends on language
+	if (wstr !== "" && dstr !== "") switch (lang) {	
 		case "en": case "de": case "es": case "pt": wsep = ", "; break;
 		case "da": wsep = (usedOptions.month == "numeric" || usedOptions.month == "2-digit") ? " " : " den "; break;
 		default : wsep = " "; break;	} 
-	// Begin forming the complete string
+
+	// Concatenate string
 	str += wstr + wsep;		// Weekday element
 	if (monthDay)   // Construct day and month in order specified
 			{ if (mstr !== "") {str += mstr + ((dstr !=="") ? msep + dstr : "")} else str += dstr }
 			else  
 			{ if (mstr !== "") {str += ((dstr !=="") ? dstr + msep : "" ) + mstr} else str += dstr}	;	
-	str += ysep + ystr ;
+	str += ysep + ystr ;	// Add year separator and year
+
 	return str; }
 }

--- a/Misc_Date_Properties/CalendarShiftCycleComputationEngine.js
+++ b/Misc_Date_Properties/CalendarShiftCycleComputationEngine.js
@@ -5,15 +5,13 @@
 // This package perform similar functions to CalendarCycleComputationEngine 
 // except that it is adapted to calendar which "shift" the intercalation year by one on a regular basis.
 // This version is particularly usefull for the extended French Revolutionary calendar
-// for which a longer ("sextile") year occur ordinarly every 4 year, but sometimes after 5 years.
-// The routine  then compute.
+// for which a longer ("sextile") year occur ordinarly every 4 year, but sometimes after 5 years, building 33 years cycles.
 // the rank of a day within a year, and then hours, minutes, seconds and milliseconds.
-// Computations on months require more specific algorithms.
 //
-// Version 1 : M2017-12-13
-// Version 1: 
-//	Changed the names of the functions
-//	The parameters are now in each package. Only very common parameters and variables are defined here.
+// Note: This package must be used together with Calendar Cycle Computation Engine.
+//
+// Version 1 : M2017-12-14
+// Version 1: tested for the French Revolutionary calendar
 //
 *//////////////////////////////////////////////////////////////////////////////////////////////
 /* Copyright Miletus 2017 - Louis A. de Fouquières
@@ -37,49 +35,14 @@
 // or the use or other dealings in the software.
 // Inquiries: www.calendriermilesien.org
 *////////////////////////////////////////////////////////////////////////////////
-/* var Chronos = { // Set of chronological constants generally used when handling Unix dates.
-  DAY_UNIT : 86400000, // One day in Unix time units
-  HOUR_UNIT : 3600000,
-  MINUTE_UNIT : 60000,
-  SECOND_UNIT : 1000
-}
-*/
-/* Parameter object structure. Replace # with numbers or literals.
-var decomposeParameterExample = {
-	timeepoch : #, origin time in milliseconds (or in the suitable unit) to be used for the decomposition, with respect to 1/1/1970 00:00 UTC.
-	coeff : [ // This array holds the coefficient used to decompose a time stamp into time cycles like eras, quadrisaeculae, centuries etc.
-		{cyclelength : #, //length of the cycle, expressed in milliseconds.
-		ceiling : #, // Infinity, or the maximum number of cycles of this size minus one in the upper cycle; the last cycle may hold an intercalary unit.
-		multiplier : #, // multiplies the number of cycle of this level to convert into target units.
-		target : #, // the unit (e.g. "year") of the decomposition element at this level. 
-		} ,
-		{ // similar elements at the lower cycle level 
-		} // end of array element
-	], // End of this array, but not end of object
-	canvas : [ // this last array is the canvas of the decomposition , e.g. "year", "month", "date", with suitable properties at each level.
-		{ name : #, // the name of the property at this level, which must match one target property of the coeff component,
-		init : #, // value of this component at epoch, and lowest value (except for the first component), e.g. 0 for month, 1 for date, 0 for hours, minutes, seconds.
-		} // End of array element (only two properties)
-	] // End of second array
-}	// End of object.
+//
+// Parameter object structure: same as in Calendar Cycle Computation Engine. 
+//
 // Constraints: 
 //	1. 	The cycles and the canvas elements shall be definined from the larger to the smaller 
-//		e.g. quadrisaeculum, then century, then quadriannum, then year, etc.
-//	2. 	The same names shall bu used for the "coeff" and the "canvas" properties, otherwise applications may return "NaN".
+//		e.g. (for French Revolutionary calendar): 33 years cycle, then Franciade (4 to 5 years), then years, the month etc.
+//	2. 	The same names shall be used for the "coeff" and the "canvas" properties, otherwise applications may return "NaN".
 //		
-*/
-/* var
-Day_milliseconds = { 	// To convert a time or a duration to and from days + milliseconds in day.
-	timeepoch : 0, 
-	coeff : [ // to be used with a Unix timestamp in ms. Decompose into days and milliseconds in day.
-	  {cyclelength : 86400000, ceiling : Infinity, multiplier : 1, target : "day_number"}, 
-	  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "milliseconds_in_day"}
-	],
-	canvas : [
-		{name : "day_number", init : 0},
-		{name : "milliseconds_in_day", init : 0},
-	]
-}*/
 /////////////////////////////////////////////
 // csceDecompose : from time serie figure to decomposition
 ///////////////////////////////////////////// 
@@ -112,25 +75,28 @@ function csceDecompose (quantity, params) { // from a chronological number, buil
 ////////////////////////////////////////////
 // csceCompose: from compound object to time serie figure.
 ////////////////////////////////////////////
-function csceCompose (cells, params) { // from an object structured as params.canvas, compute the chronological number
-	var quantity = params.timeepoch ; // initialise quantity
+function csceCompose (cells, params) { // from an object cells structured as params.canvas, compute the chronological number
+	var quantity = params.timeepoch ; // initialise Unix quantity to computation epoch
 	for (let i = 0; i < params.canvas.length; i++) { // cells value shifted as to have all 0 if at epoch
 		cells[params.canvas[i].name] -= params.canvas[i].init
 	}
-/*	Strategy: decompose year element following cycle structure
-*/
-	let currentTarget = params.coeff[0].target; 	// Set to uppermost unit (year, most often)
-	let currentCounter = cells[params.coeff[0].target]
-	let addCycle = 0; 
+//	Unlike ccceCompose, decomposition is top-down. 
+	let currentTarget = params.coeff[0].target; 	// Set to uppermost unit used for date (year, most often)
+	let currentCounter = cells[params.coeff[0].target];	// This counter shall hold the successive remainders
+	let addCycle = 0; 	// This flag says whether there is an additionnal period at end of cycle, e.g. a 5th year in the Franciade
 	for (let i = 0; i < params.coeff.length; i++) {
-	let f = 0;				// Number of "target" values (number of years, to begin with), and remainder for each cycle
-	
-	let ceiling = params.coeff[i].ceiling + addCycle;
+		let f = 0;				// Number of "target" values (number of years, to begin with)
+		if (currentTarget != params.coeff[i].target) {	// If we go to the next level (e.g. year to month), reset variables
+			// if (currentCounter != 0) alert ("Error csceCompose, i, currentCounter: ", i, currentCounter); // Debug only
+			currentTarget = params.coeff[i].target;
+			currentCounter = cells[currentTarget];
+		}
+		let ceiling = params.coeff[i].ceiling + addCycle;
 		while (currentCounter < 0) {
 			--f;
-			currentCounter += params.coeff[i].multiplier
+			currentCounter += params.coeff[i].multiplier;
 		}
-		while (currentCounter >= params.coeff[i].multiplier) && (f < ceiling) {
+		while ((currentCounter >= params.coeff[i].multiplier) && (f < ceiling)) {
 			++f;
 			currentCounter -= params.coeff[i].multiplier;
 		}

--- a/Misc_Date_Properties/CalendarShiftCycleComputationEngine.js
+++ b/Misc_Date_Properties/CalendarShiftCycleComputationEngine.js
@@ -1,0 +1,141 @@
+/* The Calendar Shift Cycle Computation Engine (CCCE)
+// 
+// Character set is UTF-8
+//
+// This package perform similar functions to CalendarCycleComputationEngine 
+// except that it is adapted to calendar which "shift" the intercalation year by one on a regular basis.
+// This version is particularly usefull for the extended French Revolutionary calendar
+// for which a longer ("sextile") year occur ordinarly every 4 year, but sometimes after 5 years.
+// The routine  then compute.
+// the rank of a day within a year, and then hours, minutes, seconds and milliseconds.
+// Computations on months require more specific algorithms.
+//
+// Version 1 : M2017-12-13
+// Version 1: 
+//	Changed the names of the functions
+//	The parameters are now in each package. Only very common parameters and variables are defined here.
+//
+*//////////////////////////////////////////////////////////////////////////////////////////////
+/* Copyright Miletus 2017 - Louis A. de Fouquières
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 1. The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+// 2. Changes with respect to any former version shall be documented.
+//
+// The software is provided "as is", without warranty of any kind,
+// express of implied, including but not limited to the warranties of
+// merchantability, fitness for a particular purpose and noninfringement.
+// In no event shall the authors of copyright holders be liable for any
+// claim, damages or other liability, whether in an action of contract,
+// tort or otherwise, arising from, out of or in connection with the software
+// or the use or other dealings in the software.
+// Inquiries: www.calendriermilesien.org
+*////////////////////////////////////////////////////////////////////////////////
+/* var Chronos = { // Set of chronological constants generally used when handling Unix dates.
+  DAY_UNIT : 86400000, // One day in Unix time units
+  HOUR_UNIT : 3600000,
+  MINUTE_UNIT : 60000,
+  SECOND_UNIT : 1000
+}
+*/
+/* Parameter object structure. Replace # with numbers or literals.
+var decomposeParameterExample = {
+	timeepoch : #, origin time in milliseconds (or in the suitable unit) to be used for the decomposition, with respect to 1/1/1970 00:00 UTC.
+	coeff : [ // This array holds the coefficient used to decompose a time stamp into time cycles like eras, quadrisaeculae, centuries etc.
+		{cyclelength : #, //length of the cycle, expressed in milliseconds.
+		ceiling : #, // Infinity, or the maximum number of cycles of this size minus one in the upper cycle; the last cycle may hold an intercalary unit.
+		multiplier : #, // multiplies the number of cycle of this level to convert into target units.
+		target : #, // the unit (e.g. "year") of the decomposition element at this level. 
+		} ,
+		{ // similar elements at the lower cycle level 
+		} // end of array element
+	], // End of this array, but not end of object
+	canvas : [ // this last array is the canvas of the decomposition , e.g. "year", "month", "date", with suitable properties at each level.
+		{ name : #, // the name of the property at this level, which must match one target property of the coeff component,
+		init : #, // value of this component at epoch, and lowest value (except for the first component), e.g. 0 for month, 1 for date, 0 for hours, minutes, seconds.
+		} // End of array element (only two properties)
+	] // End of second array
+}	// End of object.
+// Constraints: 
+//	1. 	The cycles and the canvas elements shall be definined from the larger to the smaller 
+//		e.g. quadrisaeculum, then century, then quadriannum, then year, etc.
+//	2. 	The same names shall bu used for the "coeff" and the "canvas" properties, otherwise applications may return "NaN".
+//		
+*/
+/* var
+Day_milliseconds = { 	// To convert a time or a duration to and from days + milliseconds in day.
+	timeepoch : 0, 
+	coeff : [ // to be used with a Unix timestamp in ms. Decompose into days and milliseconds in day.
+	  {cyclelength : 86400000, ceiling : Infinity, multiplier : 1, target : "day_number"}, 
+	  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "milliseconds_in_day"}
+	],
+	canvas : [
+		{name : "day_number", init : 0},
+		{name : "milliseconds_in_day", init : 0},
+	]
+}*/
+/////////////////////////////////////////////
+// csceDecompose : from time serie figure to decomposition
+///////////////////////////////////////////// 
+function csceDecompose (quantity, params) { // from a chronological number, build an compound object holding the elements as required by cparams.
+  quantity -= params.timeepoch; // set quantity to decompose into cycles to the right value.
+  var result = new Object(); // Construct intitial result 
+  for (let i = 0; i < params.canvas.length; i++) {	// Define property of result object (a date or date-time)
+    Object.defineProperty (result, params.canvas[i].name, {enumerable : true, writable : true, value : params.canvas[i].init});
+  }
+  let addCycle = 0; 	// flag that upper cycle has one more element (5 years franciade or 13 months luni-solar year)
+  for (let i = 0; i < params.coeff.length; ++i) {	// Perform decomposition by dividing by the successive cycle length
+    let r = 0; // r is the computed quotient for this level of decomposition
+    if (params.coeff[i].cyclelength == 1) r = quantity; // avoid performing a trivial divison by 1.
+    else {		// at each level, search at the same time the quotient (r) and the modulus (quantity)
+      while (quantity < 0) {
+        --r; 
+        quantity += params.coeff[i].cyclelength;
+      }
+	  let ceiling = params.coeff[i].ceiling + addCycle;
+      while ((quantity >= params.coeff[i].cyclelength) && (r < ceiling)) {
+        ++r; 
+        quantity -= params.coeff[i].cyclelength;
+      }
+	  addCycle = (r == ceiling ? 1 : 0); // if at "intercalation" section, add possibly 1 to the ceiling of next cycle
+    }
+    result[params.coeff[i].target] += r*params.coeff[i].multiplier; // add result to suitable part of result array	
+  }	
+  return result;
+}
+////////////////////////////////////////////
+// csceCompose: from compound object to time serie figure.
+////////////////////////////////////////////
+function csceCompose (cells, params) { // from an object structured as params.canvas, compute the chronological number
+	var quantity = params.timeepoch ; // initialise quantity
+	for (let i = 0; i < params.canvas.length; i++) { // cells value shifted as to have all 0 if at epoch
+		cells[params.canvas[i].name] -= params.canvas[i].init
+	}
+/*	Strategy: decompose year element following cycle structure
+*/
+	let currentTarget = params.coeff[0].target; 	// Set to uppermost unit (year, most often)
+	let currentCounter = cells[params.coeff[0].target]
+	let addCycle = 0; 
+	for (let i = 0; i < params.coeff.length; i++) {
+	let f = 0;				// Number of "target" values (number of years, to begin with), and remainder for each cycle
+	
+	let ceiling = params.coeff[i].ceiling + addCycle;
+		while (currentCounter < 0) {
+			--f;
+			currentCounter += params.coeff[i].multiplier
+		}
+		while (currentCounter >= params.coeff[i].multiplier) && (f < ceiling) {
+			++f;
+			currentCounter -= params.coeff[i].multiplier;
+		}
+		addCycle = (f == ceiling) ? 1 : 0;
+		quantity += f * params.coeff[i].cyclelength;
+	}
+	return quantity ;	
+} 

--- a/Misc_Date_Properties/CalendarShiftCycleComputationEngine.js
+++ b/Misc_Date_Properties/CalendarShiftCycleComputationEngine.js
@@ -10,7 +10,7 @@
 //
 // Note: This package must be used together with Calendar Cycle Computation Engine.
 //
-// Version 1 : M2017-12-14
+// Version 1 : M2017-12-23
 // Version 1: tested for the French Revolutionary calendar
 //
 *//////////////////////////////////////////////////////////////////////////////////////////////
@@ -38,11 +38,36 @@
 //
 // Parameter object structure: same as in Calendar Cycle Computation Engine. 
 //
+/* Parameter object structure. Replace # with numbers or literals.
+var decomposeParameterExample = {
+	timeepoch : #, origin time in milliseconds (or in the suitable unit) to be used for the decomposition, with respect to 1/1/1970 00:00 UTC.
+	coeff : [ // This array holds the coefficient used to decompose a time stamp into time cycles like eras, quadrisaeculae, centuries etc.
+		{cyclelength : #, //length of the cycle, expressed in milliseconds.
+		ceiling : #, // Infinity, or the maximum number of cycles of this size minus one in the upper cycle; 
+				// the last cycle may hold a different number of subcycles.
+		subCycleShift : #, number (-1, 0 or +1) to add to the ceiling of the cycle of the next level when the ceiling is reached at this level.
+			// For instance: the 128-year larger cycle holds three 33-year plus one 29-years subcycle: set -1; 
+			// The 33 years cycle is 8 franciades, 7 of 4 years and 1 of 5 years : +1.
+			// The 29 years cycle is (8-1) franciades, 6 of 4 years and the last one of 5 years, use +1 as well.
+		multiplier : #, // multiplies the number of cycle of this level to convert into target units.
+		target : #, // the unit (e.g. "year") of the decomposition element at this level. 
+		} ,
+		{ // similar elements at the lower cycle level 
+		} // end of array element
+	], // End of this array, but not end of object
+	canvas : [ // this last array is the canvas of the decomposition , e.g. "year", "month", "date", with suitable properties at each level.
+		{ name : #, // the name of the property at this level, which must match one target property of the coeff component,
+		init : #, // value of this component at epoch, and lowest value (except for the first component), e.g. 0 for month, 1 for date, 0 for hours, minutes, seconds.
+		} // End of array element (only two properties)
+	] // End of second array
+}	// End of object.
+
 // Constraints: 
 //	1. 	The cycles and the canvas elements shall be definined from the larger to the smaller 
 //		e.g. (for French Revolutionary calendar): 33 years cycle, then Franciade (4 to 5 years), then years, the month etc.
 //	2. 	The same names shall be used for the "coeff" and the "canvas" properties, otherwise applications may return "NaN".
-//		
+//
+*/		
 /////////////////////////////////////////////
 // csceDecompose : from time serie figure to decomposition
 ///////////////////////////////////////////// 
@@ -52,7 +77,7 @@ function csceDecompose (quantity, params) { // from a chronological number, buil
   for (let i = 0; i < params.canvas.length; i++) {	// Define property of result object (a date or date-time)
     Object.defineProperty (result, params.canvas[i].name, {enumerable : true, writable : true, value : params.canvas[i].init});
   }
-  let addCycle = 0; 	// flag that upper cycle has one more element (5 years franciade or 13 months luni-solar year)
+  let addCycle = 0; 	// flag that upper cycle has one element more or less (5 years franciade or 13 months luni-solar year)
   for (let i = 0; i < params.coeff.length; ++i) {	// Perform decomposition by dividing by the successive cycle length
     let r = 0; // r is the computed quotient for this level of decomposition
     if (params.coeff[i].cyclelength == 1) r = quantity; // avoid performing a trivial divison by 1.
@@ -66,7 +91,7 @@ function csceDecompose (quantity, params) { // from a chronological number, buil
         ++r; 
         quantity -= params.coeff[i].cyclelength;
       }
-	  addCycle = (r == ceiling ? 1 : 0); // if at "intercalation" section, add possibly 1 to the ceiling of next cycle
+	  addCycle = (r == ceiling ? params.coeff[i].subCycleShift : 0); // if at "intercalation" section, add or substract possibly 1 to the ceiling of next cycle
     }
     result[params.coeff[i].target] += r*params.coeff[i].multiplier; // add result to suitable part of result array	
   }	
@@ -100,7 +125,7 @@ function csceCompose (cells, params) { // from an object cells structured as par
 			++f;
 			currentCounter -= params.coeff[i].multiplier;
 		}
-		addCycle = (f == ceiling) ? 1 : 0;
+		addCycle = (f == ceiling) ? params.coeff[i].subCycleShift : 0;
 		quantity += f * params.coeff[i].cyclelength;
 	}
 	return quantity ;	

--- a/Misc_Date_Properties/ChronologicalCountConversion.js
+++ b/Misc_Date_Properties/ChronologicalCountConversion.js
@@ -1,0 +1,50 @@
+/* Chronological count conversion
+// Character set is UTF-8
+// This package, to be manually imported, converts the standard Unix time counter into several well-known counters
+// Version M2017-12-27 : Initial
+// No dependent file, all constants here (Day_Unit is defined again)
+// A single method added to Date object
+//	getCount (serie), where serie is one of the following chronological series
+//		"julianDay" : 0 on M-004713-12-02T12:00:00Z (1 January -4712 at noon UTC)
+//		"modifiedJulianDay" : 0 on M1858-11-27T00:00:00Z, i.e. : Julian Day - 2400000.5
+//		"nasaDay" : 0 on M1968-06-03T00:00:00Z, i.e. : Julian Day - 2440000.5
+//		"windowsCount" : 1 on M1900-01-11T00:00:00Z, used on Windows systems
+//		"macOSCount" : 0 on M1904-01-11T00:00:00Z, used on MacOS systems
+*/////////////////////////////////////////////////////////////////////////////////////////////
+/* Copyright Miletus 2017 - Louis A. de Fouquières
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 1. The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+// 2. Changes with respect to any former version shall be documented.
+//
+// The software is provided "as is", without warranty of any kind,
+// express of implied, including but not limited to the warranties of
+// merchantability, fitness for a particular purpose and noninfringement.
+// In no event shall the authors of copyright holders be liable for any
+// claim, damages or other liability, whether in an action of contract,
+// tort or otherwise, arising from, out of or in connection with the software
+// or the use or other dealings in the software.
+// Inquiries: www.calendriermilesien.org
+*////////////////////////////////////////////////////////////////////////////////
+Date.prototype.getCount = function (countType) {
+	const   
+		DAY_UNIT = 86400000,	// number of ms in one day
+		HALF_DAY_UNIT = 43200000,
+		JULIAN_DAY_UTC12_EPOCH_OFFSET = +210866760000000; // Julian Day 0 (12h UTC).
+	let convertMs = JULIAN_DAY_UTC12_EPOCH_OFFSET;	// initiate with Julian day expressed in ms
+	switch (countType) {
+		case "julianDay" : break;
+		case "modifiedJulianDay" : convertMs -= 2400000 * DAY_UNIT + HALF_DAY_UNIT; break;
+		case "nasaDay" : convertMs -= 2440000 * DAY_UNIT + HALF_DAY_UNIT; break;
+		case "windowsCount" : convertMs -= 2415018 * DAY_UNIT + HALF_DAY_UNIT; break;
+		case "macOSCount" :  convertMs -= 2416480 * DAY_UNIT + HALF_DAY_UNIT; break;
+		default : return NaN;
+	}
+	return (this.valueOf() + convertMs) /DAY_UNIT ;
+}

--- a/Misc_Date_Properties/FrenchRevDateProperties.js
+++ b/Misc_Date_Properties/FrenchRevDateProperties.js
@@ -1,8 +1,8 @@
 /* French revolutionary calendar properties added to Date object
 // Character set is UTF-8
 // This code, to be manually imported, set properties to object Date for the French Revolutionary calendar.
-// Version M2017-12-12
-// Package CalendarCycleComputationEngine is used.
+// Version M2017-12-23
+// Package CalendarShiftCycleComputationEngine is used.
 //  getFrenchRevDate : the day date as a three elements object: .year, .month, .date; .month is 0 to 11. Conversion is in local time.
 //  getFrenchRevUTCDate : same as above, in UTC time.
 //  setTimeFromFrenchRev (year, month, date, hours, minutes, seconds, milliseconds) : set Time from julian calendar date + local hour.
@@ -31,19 +31,24 @@
 *////////////////////////////////////////////////////////////////////////////////
 //
 // 1. Basic tools of this package
-/*// Import CalendarCycleComputationEngine, or make visible. */
-var FrenchRev_time_params = { // To be used with a Unix timestamp in ms. Decompose into Milesian years, months, date, hours, minutes, seconds, ms
-	timeepoch : -6004454400000, // Unix timestamp of 3 10m 1779 00h00 UTC in ms
+// Import CalendarShiftCycleComputationEngine, or make visible.
+var FrenchRev_time_params = { // To be used with a Unix timestamp in ms. Decompose into years, months, date, hours, minutes, seconds, ms
+	timeepoch : -6004454400000, // Unix timestamp of 3 10m 1779 00h00 UTC in ms, the origin for the algorithm
 	coeff : [ 
-	  {cyclelength : 1041379200000, ceiling : Infinity, multiplier : 33, target : "year"}, // The 33 years main cycle. Last franciade is 5 years.
-	  {cyclelength : 126230400000, ceiling : 7, multiplier : 4, target : "year"}, 	//The ordinary "Franciade" (4 years)
-	  {cyclelength : 31536000000, ceiling : 3, multiplier : 1, target : "year"},	//The ordinary year within the Franciade
-	  {cyclelength : 2592000000, ceiling : Infinity, multiplier : 1, target : "month"}, 
-	  {cyclelength : 86400000, ceiling : Infinity, multiplier : 1, target : "date"},
-	  {cyclelength : 3600000, ceiling : Infinity, multiplier : 1, target : "hours"},
-	  {cyclelength : 60000, ceiling : Infinity, multiplier : 1, target : "minutes"},
-	  {cyclelength : 1000, ceiling : Infinity, multiplier : 1, target : "seconds"},
-	  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "milliseconds"}
+	  {cyclelength : 4039286400000, ceiling : Infinity, subCycleShift : 0, multiplier : 128, target : "year"}, // 128 (julian) years minus 1 day.
+	  {cyclelength : 1041379200000, ceiling : 3, subCycleShift : -1, multiplier : 33, target : "year"}, // 33 years cycle. Last franciade is 5 years.
+		// The 33-years cycle contains 7 4-years franciades, and one 5-years. 
+		// subCycleShift set to -1 means: if the 33-years is the last one of the 128-years cycle, i.e. number 3 starting from 0,
+		// then it turns into a 7 franciades cycle, the first 6 being 4-years, the 7th (instead of the 8th) is 5-years.
+	  {cyclelength : 126230400000, ceiling : 7, subCycleShift : +1, multiplier : 4, target : "year"}, 	//The ordinary "Franciade" (4 years)
+		// Same principle as above: if franciade is the last one (#7 or #6 starting form #0) of upper cycle, then it is 5 years long instead of 4 years.
+	  {cyclelength : 31536000000, ceiling : 3, subCycleShift : 0, multiplier : 1, target : "year"},	//The ordinary year within the franciade
+	  {cyclelength : 2592000000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "month"}, 
+	  {cyclelength : 86400000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "date"},
+	  {cyclelength : 3600000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "hours"},
+	  {cyclelength : 60000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "minutes"},
+	  {cyclelength : 1000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "seconds"},
+	  {cyclelength : 1, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "milliseconds"}
 	],
 	canvas : [ 
 		{name : "year", init : -12},

--- a/Misc_Date_Properties/FrenchRevDateProperties.js
+++ b/Misc_Date_Properties/FrenchRevDateProperties.js
@@ -1,0 +1,92 @@
+/* French revolutionary calendar properties added to Date object
+// Character set is UTF-8
+// This code, to be manually imported, set properties to object Date for the French Revolutionary calendar.
+// Version M2017-12-12
+// Package CalendarCycleComputationEngine is used.
+//  getFrenchRevDate : the day date as a three elements object: .year, .month, .date; .month is 0 to 11. Conversion is in local time.
+//  getFrenchRevUTCDate : same as above, in UTC time.
+//  setTimeFromFrenchRev (year, month, date, hours, minutes, seconds, milliseconds) : set Time from julian calendar date + local hour.
+//  setUTCTimeFromFrenchRev (year, month, date, hours, minutes, seconds, milliseconds) : same but from UTC time zone.
+*/////////////////////////////////////////////////////////////////////////////////////////////
+/* Copyright Miletus 2017 - Louis A. de Fouquières
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 1. The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+// 2. Changes with respect to any former version shall be documented.
+//
+// The software is provided "as is", without warranty of any kind,
+// express of implied, including but not limited to the warranties of
+// merchantability, fitness for a particular purpose and noninfringement.
+// In no event shall the authors of copyright holders be liable for any
+// claim, damages or other liability, whether in an action of contract,
+// tort or otherwise, arising from, out of or in connection with the software
+// or the use or other dealings in the software.
+// Inquiries: www.calendriermilesien.org
+*////////////////////////////////////////////////////////////////////////////////
+//
+// 1. Basic tools of this package
+/*// Import CalendarCycleComputationEngine, or make visible. */
+var FrenchRev_time_params = { // To be used with a Unix timestamp in ms. Decompose into Milesian years, months, date, hours, minutes, seconds, ms
+	timeepoch : -6004454400000, // Unix timestamp of 3 10m 1779 00h00 UTC in ms
+	coeff : [ 
+	  {cyclelength : 1041379200000, ceiling : Infinity, multiplier : 33, target : "year"}, // The 33 years main cycle. Last franciade is 5 years.
+	  {cyclelength : 126230400000, ceiling : 7, multiplier : 4, target : "year"}, 	//The ordinary "Franciade" (4 years)
+	  {cyclelength : 31536000000, ceiling : 3, multiplier : 1, target : "year"},	//The ordinary year within the Franciade
+	  {cyclelength : 2592000000, ceiling : Infinity, multiplier : 1, target : "month"}, 
+	  {cyclelength : 86400000, ceiling : Infinity, multiplier : 1, target : "date"},
+	  {cyclelength : 3600000, ceiling : Infinity, multiplier : 1, target : "hours"},
+	  {cyclelength : 60000, ceiling : Infinity, multiplier : 1, target : "minutes"},
+	  {cyclelength : 1000, ceiling : Infinity, multiplier : 1, target : "seconds"},
+	  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "milliseconds"}
+	],
+	canvas : [ 
+		{name : "year", init : -12},
+		{name : "month", init : 0},
+		{name : "date", init : 1},
+		{name : "hours", init : 0},
+		{name : "minutes", init : 0},
+		{name : "seconds", init : 0},
+		{name : "milliseconds", init : 0},
+	]
+}
+//
+// 2. Methods added to Date object for French Revolutionary dates
+//
+Date.prototype.getFrenchRevDate = function () {
+  return csceDecompose (this.getTime() - (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), FrenchRev_time_params);
+}
+Date.prototype.getFrenchRevUTCDate = function () {
+  return csceDecompose (this.getTime(), FrenchRev_time_params);
+}
+Date.prototype.setTimeFromFrenchRev = function (year, month, date, 
+                                               hours = this.getHours(), minutes = this.getMinutes(), seconds = this.getSeconds(),
+                                               milliseconds = this.getMilliseconds()) {
+  this.setTime(csceCompose({
+	  'year' : year, 'month' : month, 'date' : date, 'hours' : 0, 'minutes' : 0, 'seconds' : 0, 'milliseconds' : 0
+	  }, FrenchRev_time_params));			// Date is first specified at midnight UTC.
+  this.setHours (hours, minutes, seconds, milliseconds); // Then hour part is specified
+  return this.valueOf();
+}
+Date.prototype.setUTCTimeFromFrenchRev = function (year, month = 0, date = 1,
+                                               hours = this.getUTCHours(), minutes = this.getUTCMinutes(), seconds = this.getUTCSeconds(),
+                                               milliseconds = this.getUTCMilliseconds()) {
+  this.setTime(csceCompose({
+	  'year' : year, 'month' : month, 'date' : date, 'hours' : hours, 'minutes' : minutes, 'seconds' : seconds,
+	  'milliseconds' : milliseconds
+	  }, FrenchRev_time_params));
+   return this.valueOf();
+}
+Date.prototype.toIntlFrenchRevDateString = function () {
+	var dateElements = csceDecompose (this.getTime()- (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), FrenchRev_time_params );
+	return dateElements.date+"/"+(++dateElements.month)+"/"+dateElements.year;
+}
+Date.prototype.toUTCIntlFrenchRevDateString = function () {
+	var dateElements = csceDecompose (this.getTime(), FrenchRev_time_params );
+	return dateElements.date+"/"+(++dateElements.month)+"/"+dateElements.year;
+}

--- a/Misc_Date_Properties/FrenchRevDateProperties.js
+++ b/Misc_Date_Properties/FrenchRevDateProperties.js
@@ -1,8 +1,8 @@
 /* French revolutionary calendar properties added to Date object
 // Character set is UTF-8
 // This code, to be manually imported, set properties to object Date for the French Revolutionary calendar.
-// Version M2017-12-23
-// Package CalendarShiftCycleComputationEngine is used.
+// Version M2017-12-26
+// Package CBCCE is used.
 //  getFrenchRevDate : the day date as a three elements object: .year, .month, .date; .month is 0 to 11. Conversion is in local time.
 //  getFrenchRevUTCDate : same as above, in UTC time.
 //  setTimeFromFrenchRev (year, month, date, hours, minutes, seconds, milliseconds) : set Time from julian calendar date + local hour.
@@ -31,7 +31,7 @@
 *////////////////////////////////////////////////////////////////////////////////
 //
 // 1. Basic tools of this package
-// Import CalendarShiftCycleComputationEngine, or make visible.
+// Import CBCCE, or make visible.
 var FrenchRev_time_params = { // To be used with a Unix timestamp in ms. Decompose into years, months, date, hours, minutes, seconds, ms
 	timeepoch : -6004454400000, // Unix timestamp of 3 10m 1779 00h00 UTC in ms, the origin for the algorithm
 	coeff : [ 
@@ -64,15 +64,15 @@ var FrenchRev_time_params = { // To be used with a Unix timestamp in ms. Decompo
 // 2. Methods added to Date object for French Revolutionary dates
 //
 Date.prototype.getFrenchRevDate = function () {
-  return csceDecompose (this.getTime() - (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), FrenchRev_time_params);
+  return cbcceDecompose (this.getTime() - (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), FrenchRev_time_params);
 }
 Date.prototype.getFrenchRevUTCDate = function () {
-  return csceDecompose (this.getTime(), FrenchRev_time_params);
+  return cbcceDecompose (this.getTime(), FrenchRev_time_params);
 }
 Date.prototype.setTimeFromFrenchRev = function (year, month, date, 
                                                hours = this.getHours(), minutes = this.getMinutes(), seconds = this.getSeconds(),
                                                milliseconds = this.getMilliseconds()) {
-  this.setTime(csceCompose({
+  this.setTime(cbcceCompose({
 	  'year' : year, 'month' : month, 'date' : date, 'hours' : 0, 'minutes' : 0, 'seconds' : 0, 'milliseconds' : 0
 	  }, FrenchRev_time_params));			// Date is first specified at midnight UTC.
   this.setHours (hours, minutes, seconds, milliseconds); // Then hour part is specified
@@ -81,17 +81,17 @@ Date.prototype.setTimeFromFrenchRev = function (year, month, date,
 Date.prototype.setUTCTimeFromFrenchRev = function (year, month = 0, date = 1,
                                                hours = this.getUTCHours(), minutes = this.getUTCMinutes(), seconds = this.getUTCSeconds(),
                                                milliseconds = this.getUTCMilliseconds()) {
-  this.setTime(csceCompose({
+  this.setTime(cbcceCompose({
 	  'year' : year, 'month' : month, 'date' : date, 'hours' : hours, 'minutes' : minutes, 'seconds' : seconds,
 	  'milliseconds' : milliseconds
 	  }, FrenchRev_time_params));
    return this.valueOf();
 }
 Date.prototype.toIntlFrenchRevDateString = function () {
-	var dateElements = csceDecompose (this.getTime()- (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), FrenchRev_time_params );
+	var dateElements = cbcceDecompose (this.getTime()- (this.getTimezoneOffset() * Chronos.MINUTE_UNIT), FrenchRev_time_params );
 	return dateElements.date+"/"+(++dateElements.month)+"/"+dateElements.year;
 }
 Date.prototype.toUTCIntlFrenchRevDateString = function () {
-	var dateElements = csceDecompose (this.getTime(), FrenchRev_time_params );
+	var dateElements = cbcceDecompose (this.getTime(), FrenchRev_time_params );
 	return dateElements.date+"/"+(++dateElements.month)+"/"+dateElements.year;
 }

--- a/Misc_Date_Properties/IsoWeekCalendarDateProperties.js
+++ b/Misc_Date_Properties/IsoWeekCalendarDateProperties.js
@@ -1,8 +1,8 @@
 /* ISO 8601 week calendar properties added to Date object
 // Character set is UTF-8
 // This code, to be manually imported, set properties to object Date for the ISO week calendar, which is the calendar implied by ISO 8601.
-// Version M2017-06-22
-// Package CalendarCycleComputationEngine is used.
+// Version M2017-12-26 eplace CalendarCycleComputationEngine with CBCCE
+// Package CBCCE is used.
 // Package MilesianDateProperties is used (in order to compute quickly year of date to be converted into ISO week calendar)
 //  getIsoWeekCalDate : the day date as a three elements object: .year, .week, .date; .week is 1 to 53. Conversion is in local time.
 //  getIsoWeekCalUTCDate : same as above, in UTC time.
@@ -40,12 +40,12 @@ var
 isoWeekCalendar_params = { // To be used with a Unix timestamp in ms. Decompose a delay within a year in week number and day.
 	timeepoch : 0, // 
 	coeff : [ 
-		{cyclelength : 604800000, ceiling : Infinity, multiplier : 1, target : "week"},
-		{cyclelength : 86400000, ceiling : Infinity, multiplier : 1, target : "day"},
-		{cyclelength : 3600000, ceiling : Infinity, multiplier : 1, target : "hours"},
-		{cyclelength : 60000, ceiling : Infinity, multiplier : 1, target : "minutes"},
-		{cyclelength : 1000, ceiling : Infinity, multiplier : 1, target : "seconds"},
-		{cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "milliseconds"}
+		{cyclelength : 604800000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "week"},
+		{cyclelength : 86400000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "day"},
+		{cyclelength : 3600000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "hours"},
+		{cyclelength : 60000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "minutes"},
+		{cyclelength : 1000, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "seconds"},
+		{cyclelength : 1, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "milliseconds"}
 	],
 		canvas : [ 
 		{name : "week", init : 1},
@@ -68,7 +68,7 @@ Date.prototype.getIsoWeekCalDate = function () {
 	let year = this.getMilesianDate().year; 	// Milesian year begins always before ISO week year, therefore ISO week calendar year is either Milesian year, either - 1.
 	let base = new Date (isoWeekCalendarBase(year));	// This is the first day of ISO week year.
 	if (base.valueOf() > this.valueOf()-(this.getTimezoneOffset() * Chronos.MINUTE_UNIT)) base.setTime (isoWeekCalendarBase(--year)); 
-	let compoundDate = ccceDecompose (this.valueOf() - this.getTimezoneOffset() * Chronos.MINUTE_UNIT - base.valueOf(), isoWeekCalendar_params);
+	let compoundDate = cbcceDecompose (this.valueOf() - this.getTimezoneOffset() * Chronos.MINUTE_UNIT - base.valueOf(), isoWeekCalendar_params);
 	Object.defineProperty (compoundDate, "year", {enumerable : true, writable : true, value : year});
 	return compoundDate;
 }
@@ -76,14 +76,14 @@ Date.prototype.getIsoWeekCalUTCDate = function () {
 	let year = this.getMilesianUTCDate().year; 	// Milesian year begins always before ISO week year, therefore ISO week calendar year is either Milesian year, either - 1.
 	let base = new Date (isoWeekCalendarBase(year));	// This is the first day of ISO week year.
 	if (base.valueOf() > this.valueOf()) base.setTime (isoWeekCalendarBase(--year));
-	let compoundDate = ccceDecompose (this.valueOf() - base.valueOf(), isoWeekCalendar_params);
+	let compoundDate = cbcceDecompose (this.valueOf() - base.valueOf(), isoWeekCalendar_params);
 	Object.defineProperty (compoundDate, "year", {enumerable : true, writable : true, value : year});
 	return compoundDate;
 }
 Date.prototype.setTimeFromIsoWeekCal = function (year, week, day, 
                                                hours = this.getHours(), minutes = this.getMinutes(), seconds = this.getSeconds(),
                                                milliseconds = this.getMilliseconds()) { // set time from date expressed in ISO week calendar
-    this.setTime(isoWeekCalendarBase(year) + ccceCompose({		// Set ISO week calendar date at 00:00 UTC. The year begins at isoWeekCalendarBase.
+    this.setTime(isoWeekCalendarBase(year) + cbcceCompose({		// Set ISO week calendar date at 00:00 UTC. The year begins at isoWeekCalendarBase.
 	  'week' : week, 'day' : day, 'hours' : 0, 'minutes' : 0, 'seconds' : 0, 'milliseconds' : 0 }, isoWeekCalendar_params));
 	this.setHours (hours, minutes, seconds, milliseconds);							// Then set hour of the day
 	return this.valueOf();
@@ -91,7 +91,7 @@ Date.prototype.setTimeFromIsoWeekCal = function (year, week, day,
 Date.prototype.setUTCTimeFromIsoWeekCal = function (year, week, day, 
                                                hours = this.getUTCHours(), minutes = this.getUTCMinutes(), seconds = this.getUTCSeconds(),
                                                milliseconds = this.getUTCMilliseconds()) { // set time from date expressed in ISO week calendar
-    this.setTime(isoWeekCalendarBase (year) + ccceCompose({
+    this.setTime(isoWeekCalendarBase (year) + cbcceCompose({
 	  'week' : week, 'day' : day, 'hours' : hours, 'minutes' : minutes, 'seconds' : seconds,
 	  'milliseconds' : milliseconds
 	  }, isoWeekCalendar_params));

--- a/Numeric-clock/MilesianPerpetualDisplay.js
+++ b/Numeric-clock/MilesianPerpetualDisplay.js
@@ -1,10 +1,9 @@
 /* MilseianPerpetualDisplay - Display routines of the Milesian perpetual digital calendar.
 // Character set of this file is UTF-8 
 // Error messages in another file fo coding compatbility
-// Version M2017-08-15
+// Version M2017-12-26 formal update of M2017-08-15 (dependent files)
 // 
-// to be used with the following .js files:
-//   CalendarCycleComputationEngine.js (used by other .js files)
+// directly refers to the following .js files:
 //   MilesianDateProperties.js
 //	 LunarDateProperties.js
 //	 IsoWeekCalendarDateProperties.js

--- a/Numeric-clock/MilesianPerpetual_standalone_fr.html
+++ b/Numeric-clock/MilesianPerpetual_standalone_fr.html
@@ -4,7 +4,7 @@
   <link href="milesian.css" rel="stylesheet"/>
   <title>Calendrier perpétuel numérique</title>
  
-  <script type="text/javascript" src="CalendarCycleComputationEngine.js"></script>
+  <script type="text/javascript" src="CBCCE.js"></script>
   <script type="text/javascript" src="MilesianDateProperties.js"></script>
   <script type="text/javascript" src="IsoWeekCalendarDateProperties.js"></script>
   <script type="text/javascript" src="JulianDateProperties.js"></script>

--- a/Write-Milesian-Date/writeMilesianDate.html
+++ b/Write-Milesian-Date/writeMilesianDate.html
@@ -3,7 +3,7 @@
   <meta content="text/html; charset=UTF-8" http-equiv="content-type">
   <link href="milesian.css" rel="stylesheet"/>
   <title>Date milésienne et calendriers internationaux</title>
-	<script type="text/javascript" src="CalendarCycleComputationEngine.js"></script>
+	<script type="text/javascript" src="CBCCE.js"></script>
 	<script type="text/javascript" src="MilesianDateProperties.js"></script>
  	<script type="text/javascript" src="milesianMonthNamesString.js"></script>
  	<script type="text/javascript" src="toMilesianString.js"></script>

--- a/Year-signature/MilesianYearSignature.js
+++ b/Year-signature/MilesianYearSignature.js
@@ -1,7 +1,7 @@
 /* Milesian Year Signature
 // Character set is UTF-8
 // This set of functions, to be manually imported, computes year key figures.
-// Package CalendarCycleComputationEngine is used.
+// Package CBCCE is used.
 // Each function returns a compound value with the yearly key figures for one calendar:
 //  julianSignature: for the Julian calendar,
 //  gregorianSignature: for the Gregorian calendar,
@@ -12,7 +12,9 @@
 //  eaterOffset: number of days from 21st March (30th 3m) to Easter Sunday.
 //  epact: Julian / Gregorian computus epact, Milesian mean moon epact.
 //  annualResidue: 29.5 minus epact (Milesian only).
-//  
+// Version 1: M2017-06-04
+// Version 2: M2017-12-26
+//	Use CBCCE 
 */////////////////////////////////////////////////////////////////////////////////////////////
 /* Copyright Miletus 2017 - Louis A. de Fouquières
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -34,9 +36,10 @@
 // tort or otherwise, arising from, out of or in connection with the software
 // or the use or other dealings in the software.
 // Inquiries: www.calendriermilesien.org
-*////////////////////////////////////////////////////////////////////////////////
-/*// Import CalendarCycleComputationEngine, or make visible.
-*///////////////////////////////////////////////////////////////////////////////
+*/
+///////////////////////////////////////////////////////////////////////////////
+// Import CBCCE, or make visible.
+///////////////////////////////////////////////////////////////////////////////
 function positiveModulo (dividend, divisor) {	// Positive modulo, with only positive divisor
 	if (divisor <= 0) return ;	// Stop execution and return "Undefined"
 	while (dividend < 0) dividend += divisor;
@@ -49,8 +52,8 @@ function julianSignature (year) {
 		yearParams = { 	// Decompose a Julian year figure
 			timeepoch : 0, 
 			coeff : [
-			  {cyclelength : 4, ceiling : Infinity, multiplier : 1, target : "quadriannum"}, 
-			  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "annum"}
+			  {cyclelength : 4, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "quadriannum"}, 
+			  {cyclelength : 1, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "annum"}
 			],
 			canvas : [
 				{name : "quadriannum", init : 0},
@@ -63,7 +66,7 @@ function julianSignature (year) {
 			easterResidue : 0, 	// Number of days from 21st March to computus 14th moon day.
 			easterOffset : 0, 	// Number of days from 21st March to Easter Sunday.
 		},
-		yearCoeff = ccceDecompose (year, yearParams),
+		yearCoeff = cbcceDecompose (year, yearParams),
 		gold = positiveModulo (year, 19);
 	signature.doomsday = positiveModulo(-2*yearCoeff.quadriannum + yearCoeff.annum, 7);
 	signature.easterResidue = positiveModulo (15 + 19*gold, 30);
@@ -76,10 +79,10 @@ function gregorianSignature (year) {
 		yearParams = { 	// Decompose a Gregorian year figure
 			timeepoch : 0, 
 			coeff : [
-			  {cyclelength : 400, ceiling : Infinity, multiplier : 1, target : "quadrisaeculum"}, 
-			  {cyclelength : 100, ceiling : Infinity, multiplier : 1, target : "saeculum"},
-			  {cyclelength : 4, ceiling : Infinity, multiplier : 1, target : "quadriannum"}, 
-			  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "annum"}
+			  {cyclelength : 400, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "quadrisaeculum"}, 
+			  {cyclelength : 100, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "saeculum"},
+			  {cyclelength : 4, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "quadriannum"}, 
+			  {cyclelength : 1, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "annum"}
 			],
 			canvas : [
 				{name : "quadrisaeculum", init : 0},
@@ -94,7 +97,7 @@ function gregorianSignature (year) {
 			easterResidue : 0,	 // Number of days from 21st March to computus 14th moon day.
 			easterOffset : 0,	 // Number of days from 21st March to Easter Sunday.
 		},
-		yearCoeff = ccceDecompose (year, yearParams),
+		yearCoeff = cbcceDecompose (year, yearParams),
 		gold = positiveModulo (year, 19);
 	signature.doomsday = positiveModulo(2*(1-yearCoeff.saeculum) - 2*yearCoeff.quadriannum + yearCoeff.annum, 7);
 	signature.easterResidue = positiveModulo (15 + 19*gold 	// Julian element
@@ -111,11 +114,11 @@ function milesianSignature (year) {
 		yearParams = { 	// Decompose a Milesian year figure for doomsday and Easter computus.
 			timeepoch : -800, 
 			coeff : [
-			  {cyclelength : 3200, ceiling : Infinity, multiplier : 1, target : "era"},
-			  {cyclelength : 400, ceiling : Infinity, multiplier : 1, target : "quadrisaeculum"}, 
-			  {cyclelength : 100, ceiling : Infinity, multiplier : 1, target : "saeculum"},
-			  {cyclelength : 4, ceiling : Infinity, multiplier : 1, target : "quadriannum"}, 
-			  {cyclelength : 1, ceiling : Infinity, multiplier : 1, target : "annum"}
+			  {cyclelength : 3200, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "era"},
+			  {cyclelength : 400, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "quadrisaeculum"}, 
+			  {cyclelength : 100, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "saeculum"},
+			  {cyclelength : 4, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "quadriannum"}, 
+			  {cyclelength : 1, ceiling : Infinity, subCycleShift : 0, multiplier : 1, target : "annum"}
 			],
 			canvas : [
 				{name : "era", init : 0},
@@ -132,7 +135,7 @@ function milesianSignature (year) {
 			easterResidue : 0, // Number of days from 30 3m to (milesian modified) computus 14th moon day.
 			easterOffset : 0, // Number of days from 30 3m to Easter Sunday.
 			},
-			yearCoeff = ccceDecompose (year, yearParams),
+			yearCoeff = cbcceDecompose (year, yearParams),
 			gold = positiveModulo (year, 19),
 			doomhour = new Date (0);
 		doomhour.setUTCHours (7); doomhour.setUTCMinutes (30); doomhour.setTimeFromMilesian (year, 0, 0); 

--- a/Year-signature/YearSignatureDisplay_fr.html
+++ b/Year-signature/YearSignatureDisplay_fr.html
@@ -4,7 +4,7 @@
   <link href="milesian.css" rel="stylesheet"/>
   <title>Epacte, semaine et Pâques par année</title>
 
-  <script type="text/javascript" src="CalendarCycleComputationEngine.js"></script>
+  <script type="text/javascript" src="CBCCE.js"></script>
   <script type="text/javascript" src="MilesianDateProperties.js"></script>
   <script type="text/javascript" src="LunarDateProperties.js"></script>
   <script type="text/javascript" src="MilesianYearSignature.js"></script>
@@ -16,17 +16,22 @@
 <h1 class="dateconvert">Epacte, semaine et Pâques</h1>
 <table class="dateconvert" align="center">
   <tbody>
-    <tr><form name="year" class="dateconvert" method="post" action="Javascript:setYear(document.year.year.value);" >
+    <tr><form name="year" class="dateconvert" method="post" autocomplete="off" action="Javascript:setYear(document.year.year.value);" >
 	  <th>Année:</th>
-	  <td><input class="dateconvert"  maxlength="5" size="5" name="year" value="2000"></td>	
-      <td><button class="dateconvert" name="Compute">Ok</button></td>
+	  <td><input name="year" type="number" value="2000" class="dateconvert yearnum"></td>	
+      <td><button name="Compute" class="dateconvert">Ok</button></td>
 	</form>
 	</tr>
+  </tbody>
+</table>
+<table class="dateconvert" align="center">
+  <tbody>
 	<tr>
-	  <form name="control" class="dateconvert" method="post" action="Javascript:setYearOffset(document.control.shift.value);">
+	  <form name="control" class="dateconvert" method="post" autocomplete="off" action="Javascript:setYearOffset(document.control.dir.value*document.control.shift.value);">
       <th> +/- années:</th>
-	  <td><input class="dateconvert"  maxlength="5" size="5" name="shift" value="1"></td> 
-      <td><button class="dateconvert" name="Compute" >Ok</button></td>
+	  <td><button name="minus" value="-1" class="dateconvert" formaction="Javascript:setYearOffset(-document.control.shift.value)">-</button></td>
+	  <td><input name="shift" type="number" value="1" class="dateconvert yearnum"></td> 
+      <td><button name="plus" value="+1" class="dateconvert" formaction="Javascript:setYearOffset(document.control.shift.value)">+</button></td>
     </form></tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adding the French Revolutionary calendars obliged to enhance the Calendar Computation Engine in order to cater with variable length cycles. The new version CBCCE obliges to rewrite all data structures.
In the same movement, three different pages were grouped into one single, the "milesian clock". Several branches are becoming obsolete, which will be deleted from the master.