### PR TITLE
Astro

### DIFF
--- a/calendarclock.js
+++ b/calendarclock.js
@@ -56,18 +56,25 @@ export class SolarClock {
 	constructor (clock) {
 		this.clock = clock;	// The dial and the elements to be moved
 	}
-	/** Set the hands of a solar calendar clock, after the components of a milesian date.
-	 * @since M2021-08-02
+	/** Set the hands of a solar calendar clock, after a date that is read with the Milesian calendar.
+	 * @since M2021-08-27
 	 * @param {Object} clock - a graphical object that represents the clock, that the routine will set
 	 * if existing, these elements shall be set
 	 *   @member .yearDisplay where the year is displayed
 	 *   @member .clockhand.month a hand to be rotated, indicates the month
 	 *   @member .clockhand.day a hand to be rotated, indicates the day in month
 	 *   @member .clockhand.hour a hand to be rotated, indicates the hour (12 hours dial)
-	 *   @member .clockhand.minute a hand to be rotated, minutes
-	 *   @member .clockhand.seconds a hand to be rotated, seconds
-	 *   @member .clockhand.dragon a hand to be rotated, represents the dragon i.e. the lunar nodes. 
+	 *   @member .clockhand.minute a hand to be rotated, the minute of time
+	 *   @member .clockhand.second a hand to be rotated, the second of time
+	 *   @member .clockhand.dragon a hand to be rotated, represents the dragon i.e. the lunar nodes
 	 *   @member .ampm where "am" or "pm" shall be indicated
+	 * @param (Date) the date (UTC instant) to display
+	 * @param (TZ) the time zone, system time zone if not transmitted
+	 * @param (Date) a date that expressed the position of caput draconis
+	 * @param {boolean} continous - if set, day and month hands shall move continuously during the day, if unset (default), day, month and dragon hands move by one day quantum.
+	 * @return {number} number of half-days since beginning of year.
+	 
+	 
 	 * @param {number} year - year, displayed as is in .yearDisplay
 	 * @param {number} month - month, 1 (1m) by default
 	 * @param {number} day - date in month, 1 by default
@@ -76,15 +83,19 @@ export class SolarClock {
 	 * @param {number} second - second, 0 to 59, 0 by default
 	 * @param (number) dragonMonth - if defined, the month part of the dragon equivalent date.
 	 * @param (number) dragonDay -b if defined, the day part of the dragon equivalent date.
-	 * @param {boolean} continous - if set, day and month hands shall move continuously during the day, if unset (default), day, month and dragon hands move by one day quantum.
-	 * @return {number} number of half-days since beginning of year.
 	*/
-	setHands(year = undefined, month = 1, day = 1, hour = 24, minute = 0, second = 0, dragonMonth, dragonDay, continuous = false) { 
-		var timeUnits = ["month", "day", "hour", "minute", "second", "dragon"] ;	// the time units enumerated.
+	setHands (displayDate, TZ = "", caput = displayDate, continuous = false) {
+		// (year = undefined, month = 1, day = 1, hour = 24, minute = 0, second = 0, dragonMonth, dragonDay, continuous = false) 
+		const timeUnits = ["month", "day", "hour", "minute", "second", "dragon"] ;	// the time units enumerated.
+		var clockDate = new ExtDate (milesian, displayDate.valueOf()),
+			clockCaput = new ExtDate (milesian, caput.valueOf()),
+			dateFields = clockDate.getFields (TZ), dragonFields = clockCaput.getFields(TZ),
+			[ year, month, day, hour, minute, second ] 	// dragonMonth, dragonDay
+				= [ dateFields.year, dateFields.month, dateFields.day, dateFields.hours, dateFields.minutes, dateFields.seconds ];
 		let 	halfDays = 60*(--month) + 2*Math.floor(month/2) 
 					+ (continuous ? 2*(day-1) + (hour + minute/60 + second/3600)/12 : 2*day),
-				dragon = dragonMonth == undefined || dragonDay == undefined ? 0 :
-						(60 * (--dragonMonth) + 2*Math.floor(dragonMonth/2) + 2*dragonDay) * 360 / 732;
+				dragon = dragonFields.month == undefined || dragonFields.day == undefined ? 0 :
+						(60 * (--dragonFields.month) + 2*Math.floor(dragonFields.month/2) + 2*dragonFields.day) * 360 / 732; 
 		// Number of half-days since beginning of year, at beginning of day i.e. at THE END of that day if no hour specified.
 		let	angle =	{				// set of angle values
 			"month" : halfDays * 360 / 732, 			// Angle of month hand with respect to vertical upright

--- a/converter.html
+++ b/converter.html
@@ -138,7 +138,7 @@ Created M2021-08-08 from milesianclock, and from an older version.
 			<table class="centered">
 			 <form name="gregorianswitch">
 			  <tr>
-				<td><input name="day" type="number" value="15" min="1" max="31" class="centered digit2"></td>
+				<td><input name="day" type="number" value="20" min="1" max="31" class="centered digit2"></td>
 				<td>
 				<select name="month" size="1" class="centered">
 				<option value="1">janvier</option>
@@ -150,9 +150,9 @@ Created M2021-08-08 from milesianclock, and from an older version.
 				<option value="7">juillet</option>
 				<option value="8">août</option>
 				<option value="9">septembre</option>
-				<option value="10" selected>octobre</option>
+				<option value="10">octobre</option>
 				<option value="11">novembre</option>
-				<option value="12">décembre</option>
+				<option value="12"selected>décembre</option>
 				</select> </td>
 				<td><input name="year" type="number" value="1582" min="1582" max="275760" class="centered digit4"></td>
 				<td><button class="textline">Ok</button></td>

--- a/converterdisplay.js
+++ b/converterdisplay.js
@@ -214,8 +214,7 @@ function setDisplay () {	// Disseminate targetDate and time on all display field
 	myElement = document.getElementById("clockmilesiandate"); 	// Milesian date element
 	myElement.innerHTML = clockFormat.format(targetDate);
 	// Finally update and display clock
-	milesianClock.setHands (milDate.year(TZ), milDate.month(TZ), milDate.day(TZ),
-		milDate.hours(TZ), milDate.minutes(TZ), milDate.seconds(TZ) ); // Display date on clock.
+	milesianClock.setHands (milDate, TZ); // Display date on clock.
 	milesianClock.clock.querySelector(".moonage").innerHTML = modules.Lunar.getCELunarDate(targetDate, TZ).day;
 	milesianClock.setSeasons (milDate.year("UTC")); // Display also seasons.
 

--- a/converteronload.js
+++ b/converteronload.js
@@ -42,7 +42,7 @@ var
 	calendars = [],	// an array (pointers to) calendar objects
 	targetDate = undefined, 	// new Date(),	// Reference UTC date
 	customCalIndex = 0,	// initialised and later changed.
-	switchingDate = { year : 1582, month : 12, day : 20 },
+	switchingDate = { year : 1582, month : 10, day : 15 },
 	TZ = "UTC", 	// time zone for specifying a date; "" means "system", only alternative value is "UTC". Only "UTC" used with converter.
 	TZOffset = 0,
 	// TZSettings : {mode : "", msoffset : 0},	// deprecate
@@ -171,9 +171,8 @@ function compLocalePresentationCalendar() {	// Manage date string display parame
 
 window.onload = function () {	// Initiate fields and set event listeners
 
-	document.gregorianswitch.day.value = switchingDate.day;
-	document.gregorianswitch.month.value = switchingDate.month;
-	document.gregorianswitch.year.value = switchingDate.year;
+	[ switchingDate.day, switchingDate.month, switchingDate.year ] 
+		= [ document.gregorianswitch.day.value, document.gregorianswitch.month.value, document.gregorianswitch.year.value ];
 
 	loadComplete.then (() => {
 		milesian = new modules.MilesianCalendar ("milesian",pldrDOM);

--- a/lightmilesianclock.html
+++ b/lightmilesianclock.html
@@ -4,7 +4,8 @@
 	<meta charset="UTF-8">
 	<title>Diem cognosce</title>
 <!-- 
-Versions	M2021-08-09 use common initialaser
+Versions	M2021-08-28	simplier calendarclock
+	M2021-08-09 use common initialiser
 	M2021-07-29 
 		fetchdom.js also a module
 		add seconds hand
@@ -39,8 +40,7 @@ Versions	M2021-08-09 use common initialaser
 		}
 	function setLightClockToNow() {	// Set clock to present date and time
 		lightClock.targetDate = new modules.ExtDate(lightClock.lightMilesian); // targeDate is today and now.	
-		lightClock.clockDial.setHands (lightClock.targetDate.year(), lightClock.targetDate.month(), lightClock.targetDate.day(),
-			lightClock.targetDate.getHours(), lightClock.targetDate.getMinutes(), lightClock.targetDate.getSeconds() ); // Display date on clock.
+		lightClock.clockDial.setHands (lightClock.targetDate); // Display date on clock.
 	}
 	</script>
 </head>

--- a/milesianclock.html
+++ b/milesianclock.html
@@ -3,7 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>Horloge milésienne</title>
-<!-- Version	M2021-08-14 renamed gregorian calendar to iso_8601
+<!-- Version	M2021-08-28	HTML initialises switching date and TZ
+	M2021-08-14 renamed gregorian calendar to iso_8601
 	M2021-08-05	
 		New dial with day length ratio
 		Separate Date-calendar from time and time zone
@@ -169,8 +170,8 @@ Inquiries: www.calendriermilesien.org
 		<!-- the dragon hand -->
 		  <g class="clockhand dragon" transform="rotate(0)"
 		  opacity="0.6">										
-			<polygon points="10,0 12,-20 56,-180 0,-195 -56,-180 -12,-20 -10,0" />
-			<polygon points="10,0 12,20 56,180 0,165 -56,180 -12,20 -10,0" />
+			<polygon points="10,0 12,-20 70,-180 0,-195 -70,-180 -12,-20 -10,0" />
+			<polygon points="10,0 12,20 70,180 0,165 -70,180 -12,20 -10,0" />
 		  </g>
 		<!-- the month hand -->
 		  <g class="clockhand month" transform="rotate(0)"
@@ -266,7 +267,7 @@ Inquiries: www.calendriermilesien.org
 			<table class="centered">
 			 <form name="gregorianswitch">
 			  <tr>
-				<td><input name="day" type="number" value="15" min="1" max="31" class="centered digit2"></td>
+				<td><input name="day" type="number" value="20" min="1" max="31" class="centered digit2"></td>
 				<td>
 				<select name="month" size="1" class="centered">
 				<option value="1">janvier</option>
@@ -278,9 +279,9 @@ Inquiries: www.calendriermilesien.org
 				<option value="7">juillet</option>
 				<option value="8">août</option>
 				<option value="9">septembre</option>
-				<option value="10" selected>octobre</option>
+				<option value="10">octobre</option>
 				<option value="11">novembre</option>
-				<option value="12">décembre</option>
+				<option value="12" selected>décembre</option>
 				</select> </td>
 				<td><input name="year" type="number" value="1582" min="1582" max="275760" class="centered digit4"></td>
 				<td><button class="textline">Ok</button></td>
@@ -524,7 +525,7 @@ Inquiries: www.calendriermilesien.org
 		<tr><th>Heure lunaire<br>(marées)</th><th>Date lunaire<br>(hauteur de lune)</th></tr>
 		<tr>
 			<td><input name="moontime" value="" type="text" class="centered" disabled="disabled" size="12"> </td>
-			<td><input name="moondate" value="" type="text" class="centered" disabled="disabled" size="8"> </td>
+			<td><input name="moondate" value="" type="text" class="centered" disabled="disabled" size="12"> </td>
 		</tr>
 	 </table>
 	 </section>

--- a/milesianclockdisplay.js
+++ b/milesianclockdisplay.js
@@ -175,10 +175,10 @@ function setDisplay () {	// Disseminate targetDate and time on all display field
 	milesianClock.setMoonPhase(dateComponent.age*Math.PI*2/29.5305888310185);
 	document.moon.age.value = dateComponent.age.toLocaleString(undefined,{maximumFractionDigits:2, minimumFractionDigits:2}); // age given as a decimal number
 	document.moon.residue.value = (29.5305888310185 - dateComponent.age).toLocaleString(undefined,{maximumFractionDigits:2, minimumFractionDigits:2});
-	dateComponent = modules.Lunar.getLunarDateTime( targetDate, TZ );
-	document.moon.moondate.value = lunarDateFormat.format(targetDate);
-		// dateComponent.day + " " +  (dateComponent.month) + "m";
+
+	document.moon.moondate.value = lunarDateFormat.format(modules.Lunar.getLunarDateTime( targetDate ));
 	try {
+
 		document.moon.moontime.value = new Date(targetDate.valueOf() + modules.Lunar.getLunarSunTimeAngle(targetDate))
 						.toLocaleTimeString(undefined, {timeZone: undef(TZ)} );
 	}
@@ -213,15 +213,13 @@ function setDisplay () {	// Disseminate targetDate and time on all display field
 			+ deltaTAbsDate.getUTCHours() + " h " + deltaTAbsDate.getUTCMinutes() + " min " + deltaTAbsDate.getUTCSeconds() + " s";
 	
 	// Yearly figures. Take milesian year.
-	let milesianYear = milDate.fullYear(TZ);
-	document.getElementById ("seasonsyear").innerHTML = milesianYear;
-	computeSignature(milesianYear);		// Recompute all year-specific elements
+	document.getElementById ("seasonsyear").innerHTML = mildateComponent.year;
+	computeSignature(mildateComponent.year);		// Recompute all year-specific elements
 
 	// Write Milesian date string near dial
 	myElement = document.getElementById("clockmilesiandate"); 	// Milesian date element
 	myElement.innerHTML = clockFormat.format(targetDate);
 	// Finally update and display clock
-	milesianClock.setHands (milDate.year(TZ), milDate.month(TZ), milDate.day(TZ),
-		milDate.hours(TZ), milDate.minutes(TZ), milDate.seconds(TZ), caput.month(), caput.day() ); // Display date on clock.
-	milesianClock.setSeasons (milDate.year("UTC")); // Display also seasons.
+	milesianClock.setHands (targetDate, TZ, caput); // Display date on clock.
+	milesianClock.setSeasons (mildateComponent.year); // Display also seasons.
 }

--- a/milesianclockonload.js
+++ b/milesianclockonload.js
@@ -42,7 +42,7 @@ var
 	calendars = [],	// an array (pointers to) calendar objects
 	targetDate = undefined, 	// new Date(),	// Reference UTC date
 	customCalIndex = 0,	// initialised and later changed.
-	switchingDate = { year : 1582, month : 12, day : 20 },
+	switchingDate = { year : 1582, month : 10, day : 15 },
 	TZ = "", 	// time zone for specifying a date; "" means "system", only alternative value is "UTC".
 	TZOffset = 0,
 	// TZSettings : {mode : "", msoffset : 0},	// deprecate
@@ -165,9 +165,9 @@ function compLocalePresentationCalendar() {	// Manage date string display parame
 
 window.onload = function () {	// Initiate fields and set event listeners
 
-	document.gregorianswitch.day.value = switchingDate.day;
-	document.gregorianswitch.month.value = switchingDate.month;
-	document.gregorianswitch.year.value = switchingDate.year;
+	TZ = document.TZmode.TZcontrol.value;
+	[ switchingDate.day, switchingDate.month, switchingDate.year ] 
+		= [ document.gregorianswitch.day.value, document.gregorianswitch.month.value, document.gregorianswitch.year.value ];
 	
 	loadComplete.then (() => {
 		milesian = new modules.MilesianCalendar ("milesian",pldrDOM);

--- a/seasons.js
+++ b/seasons.js
@@ -5,7 +5,8 @@ Required (directly)
 Contents
 	The externally used function is tropicEvent
 */
-/* Version	M2021-08-20 Hide internal functions and refer to DeltaT only
+/* Version	M2021-08-27 key figures as constants.
+	M2021-08-20 Hide internal functions and refer to DeltaT only
 	M2021-07-29 Adapt to calendrical-javascript
 	M2021-02-14	Use calendrical-javascript modules 
 	M2020-12-29 Adapted to new Chronos and Lunar
@@ -68,11 +69,10 @@ export const Seasons = {
 	 * @param {number} which: 0->March, 1->June, 2->September, 3->December, any other value -> Error
 	 * @return {number} the date of the event in Julian Day, Terrestrial Time
 	*/
-	equinox(year, which) {
-
+  equinox(year, which) {
 		//  Periodic terms to obtain true time
-
-		var EquinoxpTerms = new Array(
+	const 
+		EquinoxpTerms = new Array(
 			485, 324.96,   1934.136,
 			203, 337.23,  32964.467,
 			199, 342.08,     20.186,
@@ -98,52 +98,50 @@ export const Seasons = {
 			  9, 227.73,   1222.114,
 			  8,  15.45,  16859.074
 									),
-
 		JDE0tab1000 = new Array(
 		   new Array(1721139.29189, 365242.13740,  0.06134,  0.00111, -0.00071),
 		   new Array(1721233.25401, 365241.72562, -0.05323,  0.00907,  0.00025),
 		   new Array(1721325.70455, 365242.49558, -0.11677, -0.00297,  0.00074),
 		   new Array(1721414.39987, 365242.88257, -0.00769, -0.00933, -0.00006)
 								),
-
 		JDE0tab2000 = new Array(	// Meeus, ch. 18 (up to 3rd degree)
 		   new Array(2451623.80984, 365242.37404,  0.05169, -0.00411, -0.00057),
 		   new Array(2451716.56767, 365241.62603,  0.00325,  0.00888, -0.00030),
 		   new Array(2451810.21715, 365242.01767, -0.11575,  0.00337,  0.00078),
 		   new Array(2451900.05952, 365242.74049, -0.06223, -0.00823,  0.00032)
 							);
-		var deltaL, i, j, JDE0, JDE0tab, S, T, W, Y;
-		if (!Number.isInteger(which) || which < 0 || which > 3) throw RangeError ("Invalid season parameter: " + which);
+	var deltaL, i, j, JDE0, JDE0tab, S, T, W, Y;
+	if (!Number.isInteger(which) || which < 0 || which > 3) throw RangeError ("Invalid season parameter: " + which);
 
-		/*  Initialise terms for mean equinox and solstices.  
-		We have two sets: 
-			one for years prior to 1000 
-			and a second for subsequent years.  */
+	/*  Initialise terms for mean equinox and solstices.  
+	We have two sets: 
+		one for years prior to 1000 
+		and a second for subsequent years.  */
 
-		if (year < 1000) {
-			JDE0tab = JDE0tab1000;
-			Y = year / 1000;
-		} else {
-			JDE0tab = JDE0tab2000;
-			Y = (year - 2000) / 1000;
-		}
+	if (year < 1000) {
+		JDE0tab = JDE0tab1000;
+		Y = year / 1000;
+	} else {
+		JDE0tab = JDE0tab2000;
+		Y = (year - 2000) / 1000;
+	}
 
-		JDE0 =  JDE0tab[which][0] +
-			   (JDE0tab[which][1] * Y) +
-			   (JDE0tab[which][2] * Y * Y) +
-			   (JDE0tab[which][3] * Y * Y * Y) +
-			   (JDE0tab[which][4] * Y * Y * Y * Y);
-		T = (JDE0 - 2451545.0) / 36525;	// JDE0 expressed in Julian centuries from 1/1/2000 - Meeus 13-1
-		W = (35999.373 * T) - 2.47;		// M, Mean solar anomaly, Meeus ch. 16, without 2nd order term
-		deltaL = 1 + (0.0334 * dcos(W)) + (0.0007 * dcos(2 * W));
-		//  Sum the periodic terms for time T
-		S = 0;
-		for (i = j = 0; i < 24; i++) {
-			S += EquinoxpTerms[j] * dcos(EquinoxpTerms[j + 1] + (EquinoxpTerms[j + 2] * T));
-			j += 3;
-		}
-		return JDE0 + ((S * 0.00001) / deltaL);
-	},
+	JDE0 =  JDE0tab[which][0] +
+		   (JDE0tab[which][1] * Y) +
+		   (JDE0tab[which][2] * Y * Y) +
+		   (JDE0tab[which][3] * Y * Y * Y) +
+		   (JDE0tab[which][4] * Y * Y * Y * Y);
+	T = (JDE0 - 2451545.0) / 36525;	// JDE0 expressed in Julian centuries from 1/1/2000 - Meeus 13-1
+	W = (35999.373 * T) - 2.47;		// M, Mean solar anomaly, Meeus ch. 16, without 2nd order term
+	deltaL = 1 + (0.0334 * dcos(W)) + (0.0007 * dcos(2 * W));
+	//  Sum the periodic terms for time T
+	S = 0;
+	for (i = j = 0; i < 24; i++) {
+		S += EquinoxpTerms[j] * dcos(EquinoxpTerms[j + 1] + (EquinoxpTerms[j + 2] * T));
+		j += 3;
+	}
+	return JDE0 + ((S * 0.00001) / deltaL);
+  },
 	
 	/* Part 3 - the tropicEvent function: dates of solstices and equinoxes of a given year, from winter to winter.
 	*/
@@ -159,14 +157,15 @@ export const Seasons = {
 		any other value -> Error
 	 * @return {Date} the date of the event (correction with a Delta T estimate).
 	*/
-	tropicEvent (year, which) {
-		var JDE;
-		if (!Number.isInteger(which) || which < 0 || which > 4) throw RangeError("Invalid value for season parameter" + which);
-		if (year < LOWER_YEAR || year > UPPER_YEAR) throw RangeError ("Year outside seasons' computation capabilities: " + year);
-		if (which == 0) JDE = this.equinox (year-1,3)
-			else JDE = this.equinox(year, which-1);
-		let wdate = new Date(Math.round((JDE - 2440587.5)*86400000));
-		return new Date (wdate.valueOf() - getDeltaT(wdate));
-	}
+  tropicEvent (year, which) {
+	const PosixJD = 2440587.5, DayUnit = 86400000;
+	var JDE;
+	if (!Number.isInteger(which) || which < 0 || which > 4) throw RangeError("Invalid value for season parameter: " + which);
+	if (year < LOWER_YEAR || year > UPPER_YEAR) throw RangeError ("Year outside seasons' computation capabilities: " + year);
+	if (which == 0) JDE = this.equinox (year-1,3)
+		else JDE = this.equinox(year, which-1);
+	let wdate = new Date(Math.round((JDE - PosixJD)*DayUnit));
+	return new Date (wdate.valueOf() - getDeltaT(wdate));
+  }
 }
 


### PR DESCRIPTION
Astronomical computing has been deeply reviewed and enhanced.

# Seasons
Fixed parameters are set as constants, not as variables that were probably recomputed at each launch.

# Lunar
* Change names, logic and comments for astroCalend: this engine converts from UTC to TT in order to compute astronomical coordinates, and the reverse.
*  Draco parameters have been established so that the eclipse predictor may not predict "false negative". It may however predict eclipses where there are not.
* Lunar date and time is returned as a Date object, not as coordinates.

# Calendarclock
Call parameter are changed. Instead of a long list of all date parameter, the date itself is transmitted, and the reference TZ (blank or "UTC"). The draco information is passed the same way.

# Impacted calling files 
HTML and associated files

# Other changes
Some parameters are initiated from the HTML, not from js onload files.
